### PR TITLE
Add complete quiz data cloning when duplicating modules

### DIFF
--- a/src/app/api/modules/[id]/clone/route.ts
+++ b/src/app/api/modules/[id]/clone/route.ts
@@ -8,6 +8,7 @@ import { hasFacultyAccess } from '@/lib/auth/utils'
 const cloneModuleSchema = z.object({
   cloneMedia: z.boolean().optional().default(true),
   cloneCollaborators: z.boolean().optional().default(false),
+  cloneQuiz: z.boolean().optional().default(true),
   newTitle: z.string().min(1).max(200).optional(),
 })
 
@@ -47,9 +48,9 @@ export async function POST(
 
     // Validate request body
     const body = await request.json()
-    const { cloneMedia, cloneCollaborators, newTitle } = cloneModuleSchema.parse(body)
+    const { cloneMedia, cloneCollaborators, cloneQuiz, newTitle } = cloneModuleSchema.parse(body)
 
-    // Fetch the original module (must be public or user must have access)
+    // Fetch the original module with all related data
     const originalModule = await withDatabaseRetry(async () => {
       return prisma.modules.findFirst({
         where: {
@@ -81,6 +82,27 @@ export async function POST(
                   email: true,
                 },
               },
+            },
+          },
+          question_bank: {
+            include: {
+              questions: {
+                orderBy: { sort_order: 'asc' },
+                include: {
+                  options: { orderBy: { sort_order: 'asc' } },
+                },
+              },
+              sets: {
+                orderBy: { sort_order: 'asc' },
+                include: {
+                  memberships: { orderBy: { sort_order: 'asc' } },
+                },
+              },
+            },
+          },
+          quizzes: {
+            include: {
+              blocks: { orderBy: { sort_order: 'asc' } },
             },
           },
         },
@@ -120,6 +142,11 @@ export async function POST(
             cloned_from: originalModuleId,
             clone_count: 0,
             tags: originalModule.tags,
+            unlock_condition: originalModule.unlock_condition,
+            xp_reward: originalModule.xp_reward,
+            difficulty_level: originalModule.difficulty_level,
+            estimated_minutes: originalModule.estimated_minutes,
+            quest_type: originalModule.quest_type,
           },
           include: {
             users: {
@@ -200,7 +227,117 @@ export async function POST(
           }
         }
 
-        // 4. Increment clone count on original module
+        // 4. Clone quiz data if requested
+        if (cloneQuiz && originalModule.question_bank) {
+          const originalBank = originalModule.question_bank
+
+          // 4a. Create the new question bank
+          const newBank = await tx.question_banks.create({
+            data: {
+              module_id: clonedModuleId,
+              title: originalBank.title,
+              description: originalBank.description,
+            },
+          })
+
+          // 4b. Clone questions with options, building old->new ID map
+          const questionIdMap = new Map<string, string>()
+
+          for (const question of originalBank.questions) {
+            const newQuestion = await tx.bank_questions.create({
+              data: {
+                bank_id: newBank.id,
+                question_type: question.question_type,
+                question_text: question.question_text,
+                image_url: question.image_url,
+                sort_order: question.sort_order,
+                points: question.points,
+                shuffle_answers: question.shuffle_answers,
+                version: 1,
+                cloned_from: null,
+                tags: question.tags,
+                options: {
+                  create: question.options.map((opt) => ({
+                    option_text: opt.option_text,
+                    is_correct: opt.is_correct,
+                    explanation: opt.explanation,
+                    sort_order: opt.sort_order,
+                  })),
+                },
+              },
+            })
+            questionIdMap.set(question.id, newQuestion.id)
+          }
+
+          // 4c. Clone question sets with memberships, building old->new set ID map
+          const setIdMap = new Map<string, string>()
+
+          for (const set of originalBank.sets) {
+            const membershipData = set.memberships
+              .filter((m) => questionIdMap.has(m.question_id))
+              .map((m) => ({
+                question_id: questionIdMap.get(m.question_id)!,
+                sort_order: m.sort_order,
+              }))
+
+            const newSet = await tx.question_sets.create({
+              data: {
+                bank_id: newBank.id,
+                title: set.title,
+                description: set.description,
+                sort_order: set.sort_order,
+                tags: set.tags,
+                memberships: {
+                  create: membershipData,
+                },
+              },
+            })
+            setIdMap.set(set.id, newSet.id)
+          }
+
+          // 4d. Clone quizzes with blocks
+          for (const quiz of originalModule.quizzes) {
+            const newQuiz = await tx.quizzes.create({
+              data: {
+                module_id: clonedModuleId,
+                title: quiz.title,
+                description: quiz.description,
+                quiz_type: quiz.quiz_type,
+                status: 'draft',
+                xp_reward: quiz.xp_reward,
+                randomize_blocks: quiz.randomize_blocks,
+                time_limit_minutes: quiz.time_limit_minutes,
+                max_attempts: quiz.max_attempts,
+                pass_threshold: quiz.pass_threshold,
+                scoring_procedure: quiz.scoring_procedure,
+                scoring_drop_count: quiz.scoring_drop_count,
+                feedback_timing: quiz.feedback_timing,
+                feedback_depth: quiz.feedback_depth,
+                mastery_threshold: quiz.mastery_threshold,
+              },
+            })
+
+            const blockData = quiz.blocks
+              .filter((b) => setIdMap.has(b.set_id))
+              .map((b) => ({
+                quiz_id: newQuiz.id,
+                set_id: setIdMap.get(b.set_id)!,
+                title: b.title,
+                show_title: b.show_title,
+                questions_to_pull: b.questions_to_pull,
+                randomize_within: b.randomize_within,
+                sort_order: b.sort_order,
+              }))
+
+            if (blockData.length > 0) {
+              await tx.quiz_blocks.createMany({
+                data: blockData,
+              })
+            }
+          }
+        }
+
+        // 5. Increment clone count on original module
         await tx.modules.update({
           where: { id: originalModuleId },
           data: {

--- a/src/components/faculty/module-library.tsx
+++ b/src/components/faculty/module-library.tsx
@@ -141,6 +141,7 @@ export function ModuleLibrary() {
     newTitle: '',
     cloneMedia: true,
     cloneCollaborators: false,
+    cloneQuiz: true,
   })
 
   // Disable body scroll when modal is open
@@ -178,7 +179,7 @@ export function ModuleLibrary() {
       queryClient.invalidateQueries({ queryKey: ['modules'] })
       setShowCloneDialog(false)
       setModuleToClone(null)
-      setCloneOptions({ newTitle: '', cloneMedia: true, cloneCollaborators: false })
+      setCloneOptions({ newTitle: '', cloneMedia: true, cloneCollaborators: false, cloneQuiz: true })
       // Navigate to the cloned module
       router.push(`/faculty/modules/${data.module.id}`)
     },
@@ -195,6 +196,7 @@ export function ModuleLibrary() {
       newTitle: `${module.title} (Copy)`,
       cloneMedia: true,
       cloneCollaborators: false,
+      cloneQuiz: true,
     })
     setShowCloneDialog(true)
   }
@@ -1035,6 +1037,30 @@ export function ModuleLibrary() {
                     </Label>
                     <p className="text-xs text-muted-foreground mt-1">
                       Add the same collaborators to the cloned module
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-start space-x-3 p-3 rounded-lg border border-border/40 bg-muted/30">
+                  <Checkbox
+                    id="clone-quiz"
+                    checked={cloneOptions.cloneQuiz}
+                    onCheckedChange={(checked) =>
+                      setCloneOptions({
+                        ...cloneOptions,
+                        cloneQuiz: checked === true,
+                      })
+                    }
+                  />
+                  <div className="flex-1">
+                    <Label
+                      htmlFor="clone-quiz"
+                      className="text-sm font-medium cursor-pointer"
+                    >
+                      Clone quiz data
+                    </Label>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Include question bank, question sets, and quiz configurations
                     </p>
                   </div>
                 </div>

--- a/src/components/faculty/module-viewer.tsx
+++ b/src/components/faculty/module-viewer.tsx
@@ -84,6 +84,7 @@ export function ModuleViewer({ moduleId }: ModuleViewerProps) {
     newTitle: '',
     cloneMedia: true,
     cloneCollaborators: false,
+    cloneQuiz: true,
   })
 
   // Disable body scroll when modal is open
@@ -123,7 +124,7 @@ export function ModuleViewer({ moduleId }: ModuleViewerProps) {
       toast.success('Module cloned successfully!')
       queryClient.invalidateQueries({ queryKey: ['modules'] })
       setShowCloneDialog(false)
-      setCloneOptions({ newTitle: '', cloneMedia: true, cloneCollaborators: false })
+      setCloneOptions({ newTitle: '', cloneMedia: true, cloneCollaborators: false, cloneQuiz: true })
       // Navigate to the cloned module
       router.push(`/faculty/modules/${data.module.id}`)
     },
@@ -255,6 +256,7 @@ export function ModuleViewer({ moduleId }: ModuleViewerProps) {
                     newTitle: `${module.title} (Copy)`,
                     cloneMedia: true,
                     cloneCollaborators: false,
+                    cloneQuiz: true,
                   })
                   setShowCloneDialog(true)
                 }}
@@ -507,6 +509,30 @@ export function ModuleViewer({ moduleId }: ModuleViewerProps) {
                     </Label>
                     <p className="text-xs text-muted-foreground mt-1">
                       Add the same collaborators to the cloned module
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-start space-x-3 p-3 rounded-lg border border-border/40 bg-muted/30">
+                  <Checkbox
+                    id="clone-quiz"
+                    checked={cloneOptions.cloneQuiz}
+                    onCheckedChange={(checked) =>
+                      setCloneOptions({
+                        ...cloneOptions,
+                        cloneQuiz: checked === true,
+                      })
+                    }
+                  />
+                  <div className="flex-1">
+                    <Label
+                      htmlFor="clone-quiz"
+                      className="text-sm font-medium cursor-pointer"
+                    >
+                      Clone quiz data
+                    </Label>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Include question bank, question sets, and quiz configurations
                     </p>
                   </div>
                 </div>

--- a/src/components/public/module-catalog.tsx
+++ b/src/components/public/module-catalog.tsx
@@ -87,6 +87,7 @@ export function ModuleCatalog({ initialSearch = '', session }: ModuleCatalogProp
     newTitle: '',
     cloneMedia: true,
     cloneCollaborators: false,
+    cloneQuiz: true,
   })
 
   const isFaculty = session?.user?.role === 'faculty' || session?.user?.role === 'admin'
@@ -126,7 +127,7 @@ export function ModuleCatalog({ initialSearch = '', session }: ModuleCatalogProp
       queryClient.invalidateQueries({ queryKey: ['modules'] })
       setShowCloneDialog(false)
       setModuleToClone(null)
-      setCloneOptions({ newTitle: '', cloneMedia: true, cloneCollaborators: false })
+      setCloneOptions({ newTitle: '', cloneMedia: true, cloneCollaborators: false, cloneQuiz: true })
       // Navigate to the cloned module
       router.push(`/faculty/modules/${data.module.id}`)
     },
@@ -143,6 +144,7 @@ export function ModuleCatalog({ initialSearch = '', session }: ModuleCatalogProp
       newTitle: `${module.title} (Copy)`,
       cloneMedia: true,
       cloneCollaborators: false,
+      cloneQuiz: true,
     })
     setShowCloneDialog(true)
   }
@@ -789,6 +791,30 @@ export function ModuleCatalog({ initialSearch = '', session }: ModuleCatalogProp
                     </Label>
                     <p className="text-xs text-muted-foreground mt-1">
                       Add the same collaborators to the cloned module
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-start space-x-3 p-3 rounded-lg border border-border/40 bg-muted/30">
+                  <Checkbox
+                    id="clone-quiz"
+                    checked={cloneOptions.cloneQuiz}
+                    onCheckedChange={(checked) =>
+                      setCloneOptions({
+                        ...cloneOptions,
+                        cloneQuiz: checked === true,
+                      })
+                    }
+                  />
+                  <div className="flex-1">
+                    <Label
+                      htmlFor="clone-quiz"
+                      className="text-sm font-medium cursor-pointer"
+                    >
+                      Clone quiz data
+                    </Label>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Include question bank, question sets, and quiz configurations
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Deep-clone all quiz data when cloning a module: question bank, questions with options, question sets with memberships, quizzes (mastery check + assessment), and quiz blocks
- Uses ID remapping (`Map<oldId, newId>`) inside a Prisma transaction to maintain referential integrity across cloned records
- Adds "Clone quiz data" checkbox (default: checked) to all three clone dialogs (module library, module viewer, public catalog)
- Also copies previously missing gamification fields: `unlock_condition`, `xp_reward`, `difficulty_level`, `estimated_minutes`, `quest_type`

## Test plan
- [x] `npm run build` passes with no type errors
- [x] Deployed to Vercel and tested end-to-end
- [x] Cloned "Python Programming Basics" module (5 questions, 2 sets, mastery check, assessment)
- [x] Verified Question Bank sub-tab: all 5 questions with correct types and point values
- [x] Verified question sets: "Core Concepts" (3 Q) and "Advanced Topics" (3 Q) with correct memberships
- [x] Verified Mastery Check: cloned config with Block 1 pulling from Core Concepts
- [x] Verified Assessment: cloned config with time limit, max attempts, scoring, feedback settings, Block 1 pulling from Advanced Topics
- [x] Cloned module starts as private draft (independent from original)
- [x] Clone dialog shows "Clone quiz data" checkbox in all three locations