### PR TITLE
Course groups, unified gradebook export, bulk media upload speedup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "eslint": "^9.32.0",
         "eslint-config-next": "15.5.0",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "exceljs": "^4.4.0",
         "globals": "^15.15.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.462.0",
@@ -997,6 +998,47 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.2",
@@ -5344,6 +5386,87 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -5535,6 +5658,12 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5668,6 +5797,28 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5679,6 +5830,47 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -5756,6 +5948,32 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/c12": {
@@ -5916,6 +6134,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -6135,6 +6365,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6154,6 +6399,37 @@
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/crelt": {
@@ -6469,6 +6745,12 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -6670,6 +6952,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -6733,6 +7045,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -7486,6 +7807,26 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -7527,6 +7868,19 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -7760,6 +8114,18 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7772,6 +8138,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/function-bind": {
@@ -8000,6 +8382,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -8172,6 +8560,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8196,6 +8590,23 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -8827,6 +9238,39 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8854,6 +9298,39 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -8865,6 +9342,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -8900,6 +9386,12 @@
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "license": "MIT"
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8926,15 +9418,88 @@
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
       "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -9948,6 +10513,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/monaco-editor": {
       "version": "0.54.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
@@ -10363,6 +10940,15 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10445,6 +11031,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10489,6 +11081,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -10785,6 +11386,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -11319,6 +11926,50 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -11533,6 +12184,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -11581,6 +12266,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -11612,6 +12303,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/scheduler": {
@@ -11677,6 +12380,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.3",
@@ -11907,6 +12616,15 @@
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
       "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -12295,6 +13013,22 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -12367,6 +13101,15 @@
         "@tiptap/pm": "^2.0.0 || ^3.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12384,6 +13127,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -12739,6 +13491,45 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -12835,6 +13626,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vaul": {
       "version": "0.9.9",
@@ -13127,6 +13927,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -13147,6 +13953,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.6.0",
@@ -13170,6 +13982,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "eslint": "^9.32.0",
     "eslint-config-next": "15.5.0",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "exceljs": "^4.4.0",
     "globals": "^15.15.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",

--- a/prisma/migrations/20260409080439_add_course_groups/migration.sql
+++ b/prisma/migrations/20260409080439_add_course_groups/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable
+CREATE TABLE "public"."course_groups" (
+    "id" TEXT NOT NULL,
+    "course_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "canvas_course_id" TEXT,
+    "created_by" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "course_groups_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."course_group_memberships" (
+    "id" TEXT NOT NULL,
+    "group_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "added_by" TEXT NOT NULL,
+    "added_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "course_group_memberships_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "course_groups_course_id_idx" ON "public"."course_groups"("course_id");
+
+-- CreateIndex
+CREATE INDEX "course_groups_canvas_course_id_idx" ON "public"."course_groups"("canvas_course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_groups_course_id_name_key" ON "public"."course_groups"("course_id", "name");
+
+-- CreateIndex
+CREATE INDEX "course_group_memberships_user_id_idx" ON "public"."course_group_memberships"("user_id");
+
+-- CreateIndex
+CREATE INDEX "course_group_memberships_group_id_idx" ON "public"."course_group_memberships"("group_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_group_memberships_group_id_user_id_key" ON "public"."course_group_memberships"("group_id", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "public"."course_groups" ADD CONSTRAINT "course_groups_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_groups" ADD CONSTRAINT "course_groups_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_group_memberships" ADD CONSTRAINT "course_group_memberships_group_id_fkey" FOREIGN KEY ("group_id") REFERENCES "public"."course_groups"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_group_memberships" ADD CONSTRAINT "course_group_memberships_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."course_group_memberships" ADD CONSTRAINT "course_group_memberships_added_by_fkey" FOREIGN KEY ("added_by") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model courses {
   users           users                  @relation(fields: [author_id], references: [id], onDelete: Restrict)
   collaborators   course_collaborators[]
   course_tracking course_tracking[]
+  course_groups   course_groups[]
 
   // Progress tracking (Week 4)
   module_progress module_progress[]      @relation("CourseProgress")
@@ -251,6 +252,11 @@ model users {
 
   // Program Map & Learning Paths (Program Visualization Feature)
   created_learning_paths learning_paths[]       @relation("LearningPathCreator")
+
+  // Course groups (Canvas LMS mapping)
+  course_group_memberships  course_group_memberships[] @relation("CourseGroupMember")
+  added_group_members       course_group_memberships[] @relation("CourseGroupMemberAdder")
+  created_course_groups     course_groups[]            @relation("CourseGroupCreator")
 
   @@index([role])
   @@index([account_status])
@@ -917,4 +923,49 @@ model quiz_response_events {
   @@index([question_id])
   @@index([user_id])
   @@index([module_id])
+}
+
+// ==================== COURSE GROUPS (Canvas LMS Mapping) ====================
+
+// A faculty-defined subset of enrolled students within a course.
+// Since the platform is open (anyone can enroll), groups give faculty a way
+// to scope grade exports and (eventually) Canvas grade sync to just their
+// actual section roster.
+model course_groups {
+  id               String   @id @default(cuid())
+  course_id        String
+  name             String   // e.g. "Spring 2026 Section A"
+  description      String?
+  canvas_course_id String?  // Canvas course/section ID for downstream grade sync
+  created_by       String
+  created_at       DateTime @default(now())
+  updated_at       DateTime @updatedAt
+
+  course      courses                    @relation(fields: [course_id], references: [id], onDelete: Cascade)
+  creator     users                      @relation("CourseGroupCreator", fields: [created_by], references: [id], onDelete: Restrict)
+  memberships course_group_memberships[]
+
+  @@unique([course_id, name])
+  @@index([course_id])
+  @@index([canvas_course_id])
+}
+
+// Membership in a course group. Constraint: a user can be in at most one
+// group per course. This is enforced at the API layer (not via a DB unique
+// constraint on user_id + course_id, because course_id lives on the parent
+// course_groups row, not on membership).
+model course_group_memberships {
+  id        String   @id @default(cuid())
+  group_id  String
+  user_id   String
+  added_by  String
+  added_at  DateTime @default(now())
+
+  group  course_groups @relation(fields: [group_id], references: [id], onDelete: Cascade)
+  user   users         @relation("CourseGroupMember", fields: [user_id], references: [id], onDelete: Cascade)
+  adder  users         @relation("CourseGroupMemberAdder", fields: [added_by], references: [id], onDelete: Restrict)
+
+  @@unique([group_id, user_id])
+  @@index([user_id])
+  @@index([group_id])
 }

--- a/src/app/api/faculty/analytics/[courseId]/route.ts
+++ b/src/app/api/faculty/analytics/[courseId]/route.ts
@@ -23,6 +23,9 @@ export async function GET(
       );
     }
 
+    const { searchParams } = new URL(request.url);
+    const groupId = searchParams.get('groupId') || null;
+
     // Verify course exists
     const course = await withDatabaseRetry(async () => {
       return await prisma.courses.findUnique({
@@ -54,12 +57,33 @@ export async function GET(
       );
     }
 
-    // Fetch enrollment data
+    // If a groupId is provided, verify it belongs to this course and collect
+    // the member user IDs — every subsequent query is restricted to those users.
+    let groupMemberIds: string[] | null = null;
+    if (groupId) {
+      const group = await withDatabaseRetry(async () => {
+        return await prisma.course_groups.findUnique({
+          where: { id: groupId },
+          select: {
+            id: true,
+            course_id: true,
+            memberships: { select: { user_id: true } },
+          },
+        });
+      });
+      if (!group || group.course_id !== courseId) {
+        return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+      }
+      groupMemberIds = group.memberships.map((m) => m.user_id);
+    }
+
+    // Fetch enrollment data (optionally scoped to group members)
     const enrollments = await withDatabaseRetry(async () => {
       return await prisma.course_tracking.findMany({
         where: {
           course_id: courseId,
           status: 'active',
+          ...(groupMemberIds !== null && { user_id: { in: groupMemberIds } }),
         },
         select: {
           id: true,
@@ -92,11 +116,12 @@ export async function GET(
         )
       : 0;
 
-    // Fetch module-level analytics
+    // Fetch module-level analytics (optionally scoped to group members)
     const moduleProgress = await withDatabaseRetry(async () => {
       return await prisma.module_progress.findMany({
         where: {
           course_id: courseId,
+          ...(groupMemberIds !== null && { user_id: { in: groupMemberIds } }),
         },
         select: {
           module_id: true,
@@ -159,7 +184,7 @@ export async function GET(
     // Sort by completion count (most popular first)
     moduleAnalytics.sort((a, b) => b.completedCount - a.completedCount);
 
-    // Get recent activity (last 10 completions)
+    // Get recent activity (last 10 completions, optionally scoped to group members)
     const recentActivity = await withDatabaseRetry(async () => {
       return await prisma.module_progress.findMany({
         where: {
@@ -168,6 +193,7 @@ export async function GET(
           completed_at: {
             not: null,
           },
+          ...(groupMemberIds !== null && { user_id: { in: groupMemberIds } }),
         },
         select: {
           module: {
@@ -184,7 +210,7 @@ export async function GET(
       });
     });
 
-    // Get enrollment trend (last 30 days)
+    // Get enrollment trend (last 30 days, optionally scoped to group members)
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
@@ -196,6 +222,7 @@ export async function GET(
           started_at: {
             gte: thirtyDaysAgo,
           },
+          ...(groupMemberIds !== null && { user_id: { in: groupMemberIds } }),
         },
         _count: {
           id: true,

--- a/src/app/api/faculty/courses/[id]/groups/[groupId]/members/[userId]/route.ts
+++ b/src/app/api/faculty/courses/[id]/groups/[groupId]/members/[userId]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth/config';
+import { prisma } from '@/lib/db';
+import { withDatabaseRetry } from '@/lib/retry';
+import { hasFacultyAccess } from '@/lib/auth/utils';
+import { canEditCourseWithRetry } from '@/lib/collaboration/permissions';
+
+/**
+ * DELETE /api/faculty/courses/[id]/groups/[groupId]/members/[userId]
+ * Remove a single member from a group.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; groupId: string; userId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId, groupId, userId } = await params;
+    const hasAccess = await canEditCourseWithRetry(session.user.id, courseId);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'You do not have permission to edit this course' },
+        { status: 403 }
+      );
+    }
+
+    // Verify the group belongs to this course, and the membership exists
+    const group = await withDatabaseRetry(async () => {
+      return prisma.course_groups.findUnique({
+        where: { id: groupId },
+        select: { id: true, course_id: true },
+      });
+    });
+    if (!group || group.course_id !== courseId) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+
+    const deleted = await withDatabaseRetry(async () => {
+      return prisma.course_group_memberships.deleteMany({
+        where: { group_id: groupId, user_id: userId },
+      });
+    });
+
+    if (deleted.count === 0) {
+      return NextResponse.json(
+        { error: 'Membership not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error removing group member:', error);
+    return NextResponse.json(
+      { error: 'Failed to remove group member' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/faculty/courses/[id]/groups/[groupId]/members/route.ts
+++ b/src/app/api/faculty/courses/[id]/groups/[groupId]/members/route.ts
@@ -1,0 +1,347 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { auth } from '@/lib/auth/config';
+import { prisma } from '@/lib/db';
+import { withDatabaseRetry } from '@/lib/retry';
+import { hasFacultyAccess } from '@/lib/auth/utils';
+import { canEditCourseWithRetry } from '@/lib/collaboration/permissions';
+
+/**
+ * Two add modes:
+ *  - `{ userIds: [...] }` — faculty picks from a list of already-enrolled students
+ *  - `{ emails:  [...] }` — faculty pastes a list of emails (supports bulk upload)
+ *
+ * Both modes run through the same pipeline and return a detailed per-entry
+ * report. We accept either but require exactly one to be non-empty so the
+ * client UI can keep the two paths visually separate.
+ */
+const addMembersSchema = z
+  .object({
+    userIds: z.array(z.string().min(1)).optional(),
+    emails: z.array(z.string().trim().toLowerCase()).optional(),
+  })
+  .refine(
+    (v) => (v.userIds && v.userIds.length > 0) || (v.emails && v.emails.length > 0),
+    { message: 'Provide userIds or emails' }
+  );
+
+type AddResult = {
+  input: string; // the original userId or email the caller provided
+  status:
+    | 'added'
+    | 'already_in_group'
+    | 'already_in_other_group'
+    | 'not_enrolled'
+    | 'not_found'
+    | 'invalid_email';
+  userId?: string;
+  email?: string;
+  name?: string;
+  conflictGroupName?: string;
+};
+
+async function findGroupInCourse(groupId: string, courseId: string) {
+  return withDatabaseRetry(async () => {
+    const group = await prisma.course_groups.findUnique({
+      where: { id: groupId },
+      select: { id: true, course_id: true, name: true },
+    });
+    if (!group || group.course_id !== courseId) return null;
+    return group;
+  });
+}
+
+/**
+ * GET /api/faculty/courses/[id]/groups/[groupId]/members
+ * List all members of a group with user details.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; groupId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId, groupId } = await params;
+    const hasAccess = await canEditCourseWithRetry(session.user.id, courseId);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'You do not have permission to view this course' },
+        { status: 403 }
+      );
+    }
+
+    const existing = await findGroupInCourse(groupId, courseId);
+    if (!existing) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+
+    const members = await withDatabaseRetry(async () => {
+      return prisma.course_group_memberships.findMany({
+        where: { group_id: groupId },
+        orderBy: { added_at: 'asc' },
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              avatar_url: true,
+              role: true,
+            },
+          },
+        },
+      });
+    });
+
+    return NextResponse.json({
+      members: members.map((m) => ({
+        id: m.id,
+        userId: m.user.id,
+        name: m.user.name,
+        email: m.user.email,
+        avatarUrl: m.user.avatar_url,
+        role: m.user.role,
+        addedAt: m.added_at.toISOString(),
+      })),
+    });
+  } catch (error) {
+    console.error('Error listing group members:', error);
+    return NextResponse.json(
+      { error: 'Failed to list group members' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/faculty/courses/[id]/groups/[groupId]/members
+ * Add members to a group. Supports both single-user (from picker) and bulk
+ * (from email textarea). Returns a per-entry report so the UI can show faculty
+ * exactly what happened for each row they pasted.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; groupId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId, groupId } = await params;
+    const hasAccess = await canEditCourseWithRetry(session.user.id, courseId);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'You do not have permission to edit this course' },
+        { status: 403 }
+      );
+    }
+
+    const existing = await findGroupInCourse(groupId, courseId);
+    if (!existing) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { userIds = [], emails = [] } = addMembersSchema.parse(body);
+
+    const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    // Deduplicate and, for the email path, pre-filter invalid addresses so
+    // the caller gets a clear "invalid_email" marker per row.
+    const cleanEmails = Array.from(new Set(emails.filter(Boolean)));
+    const invalidEmails = cleanEmails.filter((e) => !EMAIL_RE.test(e));
+    const validEmails = cleanEmails.filter((e) => EMAIL_RE.test(e));
+    const cleanUserIds = Array.from(new Set(userIds.filter(Boolean)));
+
+    // Resolve emails -> users in one query. Missing emails will be flagged
+    // as 'not_found' based on the diff below.
+    const usersByEmail =
+      validEmails.length > 0
+        ? await withDatabaseRetry(async () => {
+            return prisma.users.findMany({
+              where: { email: { in: validEmails } },
+              select: { id: true, email: true, name: true },
+            });
+          })
+        : [];
+    const emailToUser = new Map(usersByEmail.map((u) => [u.email.toLowerCase(), u]));
+
+    // Resolve userIds -> users (for the picker path we already know they exist,
+    // but verify anyway in case the client is stale).
+    const usersById =
+      cleanUserIds.length > 0
+        ? await withDatabaseRetry(async () => {
+            return prisma.users.findMany({
+              where: { id: { in: cleanUserIds } },
+              select: { id: true, email: true, name: true },
+            });
+          })
+        : [];
+    const idToUser = new Map(usersById.map((u) => [u.id, u]));
+
+    // Collect the unique candidate user IDs we actually need to check/insert,
+    // each tagged with the original caller-provided input string so the
+    // response report stays aligned with what the UI sent.
+    type Candidate = { input: string; user: { id: string; email: string; name: string } };
+    const candidates: Candidate[] = [];
+    for (const uid of cleanUserIds) {
+      const u = idToUser.get(uid);
+      if (u) candidates.push({ input: uid, user: u });
+    }
+    for (const email of validEmails) {
+      const u = emailToUser.get(email);
+      if (u) candidates.push({ input: email, user: u });
+    }
+
+    const candidateUserIds = Array.from(new Set(candidates.map((c) => c.user.id)));
+
+    // Check enrollment: a user must be in course_tracking for this course
+    // before they can be added to a group. Otherwise the group is meaningless.
+    const enrollments =
+      candidateUserIds.length > 0
+        ? await withDatabaseRetry(async () => {
+            return prisma.course_tracking.findMany({
+              where: {
+                course_id: courseId,
+                user_id: { in: candidateUserIds },
+              },
+              select: { user_id: true },
+            });
+          })
+        : [];
+    const enrolledIds = new Set(enrollments.map((e) => e.user_id));
+
+    // Check existing memberships across ALL groups in this course. Gives us
+    // the one-group-per-course enforcement + lets us tell the faculty which
+    // group is conflicting.
+    const otherGroupMemberships =
+      candidateUserIds.length > 0
+        ? await withDatabaseRetry(async () => {
+            return prisma.course_group_memberships.findMany({
+              where: {
+                user_id: { in: candidateUserIds },
+                group: { course_id: courseId },
+              },
+              include: {
+                group: { select: { id: true, name: true } },
+              },
+            });
+          })
+        : [];
+    const userToExistingGroup = new Map(
+      otherGroupMemberships.map((m) => [m.user_id, m.group])
+    );
+
+    // Build the report + the set of memberships we actually need to insert.
+    const report: AddResult[] = [];
+    const toInsert: { userId: string; input: string }[] = [];
+    const seenInBatch = new Set<string>();
+
+    for (const email of invalidEmails) {
+      report.push({ input: email, email, status: 'invalid_email' });
+    }
+
+    for (const uid of cleanUserIds) {
+      if (!idToUser.has(uid)) {
+        report.push({ input: uid, status: 'not_found' });
+      }
+    }
+    for (const email of validEmails) {
+      if (!emailToUser.has(email)) {
+        report.push({ input: email, email, status: 'not_found' });
+      }
+    }
+
+    for (const { input, user } of candidates) {
+      // Dedup within the same batch in case the caller sent the same user
+      // via both paths (e.g. both id and email).
+      if (seenInBatch.has(user.id)) continue;
+      seenInBatch.add(user.id);
+
+      if (!enrolledIds.has(user.id)) {
+        report.push({
+          input,
+          userId: user.id,
+          email: user.email,
+          name: user.name,
+          status: 'not_enrolled',
+        });
+        continue;
+      }
+
+      const existingMembership = userToExistingGroup.get(user.id);
+      if (existingMembership) {
+        if (existingMembership.id === groupId) {
+          report.push({
+            input,
+            userId: user.id,
+            email: user.email,
+            name: user.name,
+            status: 'already_in_group',
+          });
+        } else {
+          report.push({
+            input,
+            userId: user.id,
+            email: user.email,
+            name: user.name,
+            status: 'already_in_other_group',
+            conflictGroupName: existingMembership.name,
+          });
+        }
+        continue;
+      }
+
+      toInsert.push({ userId: user.id, input });
+      report.push({
+        input,
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+        status: 'added',
+      });
+    }
+
+    if (toInsert.length > 0) {
+      await withDatabaseRetry(async () => {
+        return prisma.course_group_memberships.createMany({
+          data: toInsert.map((t) => ({
+            group_id: groupId,
+            user_id: t.userId,
+            added_by: session.user.id,
+          })),
+        });
+      });
+    }
+
+    const summary = {
+      added: report.filter((r) => r.status === 'added').length,
+      alreadyInGroup: report.filter((r) => r.status === 'already_in_group').length,
+      alreadyInOtherGroup: report.filter((r) => r.status === 'already_in_other_group')
+        .length,
+      notEnrolled: report.filter((r) => r.status === 'not_enrolled').length,
+      notFound: report.filter((r) => r.status === 'not_found').length,
+      invalidEmail: report.filter((r) => r.status === 'invalid_email').length,
+    };
+
+    return NextResponse.json({ report, summary });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation error', details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error('Error adding group members:', error);
+    return NextResponse.json(
+      { error: 'Failed to add group members' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/faculty/courses/[id]/groups/[groupId]/route.ts
+++ b/src/app/api/faculty/courses/[id]/groups/[groupId]/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { auth } from '@/lib/auth/config';
+import { prisma } from '@/lib/db';
+import { withDatabaseRetry } from '@/lib/retry';
+import { hasFacultyAccess } from '@/lib/auth/utils';
+import { canEditCourseWithRetry } from '@/lib/collaboration/permissions';
+
+const updateGroupSchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  description: z.string().trim().max(500).optional().nullable(),
+  canvas_course_id: z.string().trim().max(100).optional().nullable(),
+});
+
+// Helper: look up group and confirm it belongs to the expected course.
+// Returns null if not found or course mismatch (treat both as 404).
+async function findGroupInCourse(groupId: string, courseId: string) {
+  return withDatabaseRetry(async () => {
+    const group = await prisma.course_groups.findUnique({
+      where: { id: groupId },
+      select: { id: true, course_id: true, name: true },
+    });
+    if (!group || group.course_id !== courseId) return null;
+    return group;
+  });
+}
+
+/**
+ * PATCH /api/faculty/courses/[id]/groups/[groupId]
+ * Update a group's name, description, or canvas_course_id.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; groupId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId, groupId } = await params;
+    const hasAccess = await canEditCourseWithRetry(session.user.id, courseId);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'You do not have permission to edit this course' },
+        { status: 403 }
+      );
+    }
+
+    const existing = await findGroupInCourse(groupId, courseId);
+    if (!existing) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const updates = updateGroupSchema.parse(body);
+
+    // If renaming, check for collision with another group in this course
+    if (updates.name && updates.name !== existing.name) {
+      const collision = await withDatabaseRetry(async () => {
+        return prisma.course_groups.findFirst({
+          where: {
+            course_id: courseId,
+            name: updates.name!,
+            NOT: { id: groupId },
+          },
+          select: { id: true },
+        });
+      });
+      if (collision) {
+        return NextResponse.json(
+          { error: `A group named "${updates.name}" already exists in this course` },
+          { status: 409 }
+        );
+      }
+    }
+
+    const updated = await withDatabaseRetry(async () => {
+      return prisma.course_groups.update({
+        where: { id: groupId },
+        data: {
+          ...(updates.name !== undefined && { name: updates.name }),
+          ...(updates.description !== undefined && {
+            description: updates.description || null,
+          }),
+          ...(updates.canvas_course_id !== undefined && {
+            canvas_course_id: updates.canvas_course_id || null,
+          }),
+        },
+        include: {
+          _count: { select: { memberships: true } },
+          creator: { select: { id: true, name: true, email: true } },
+        },
+      });
+    });
+
+    return NextResponse.json({
+      group: {
+        id: updated.id,
+        name: updated.name,
+        description: updated.description,
+        canvasCourseId: updated.canvas_course_id,
+        memberCount: updated._count.memberships,
+        createdAt: updated.created_at.toISOString(),
+        updatedAt: updated.updated_at.toISOString(),
+        creator: updated.creator,
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation error', details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error('Error updating course group:', error);
+    return NextResponse.json(
+      { error: 'Failed to update course group' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/faculty/courses/[id]/groups/[groupId]
+ * Delete a group. Memberships cascade via the FK.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; groupId: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId, groupId } = await params;
+    const hasAccess = await canEditCourseWithRetry(session.user.id, courseId);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'You do not have permission to edit this course' },
+        { status: 403 }
+      );
+    }
+
+    const existing = await findGroupInCourse(groupId, courseId);
+    if (!existing) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+
+    await withDatabaseRetry(async () => {
+      return prisma.course_groups.delete({ where: { id: groupId } });
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting course group:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete course group' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/faculty/courses/[id]/groups/route.ts
+++ b/src/app/api/faculty/courses/[id]/groups/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { auth } from '@/lib/auth/config';
+import { prisma } from '@/lib/db';
+import { withDatabaseRetry } from '@/lib/retry';
+import { hasFacultyAccess } from '@/lib/auth/utils';
+import { canEditCourseWithRetry } from '@/lib/collaboration/permissions';
+
+const createGroupSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(100),
+  description: z.string().trim().max(500).optional().nullable(),
+  canvas_course_id: z.string().trim().max(100).optional().nullable(),
+});
+
+/**
+ * GET /api/faculty/courses/[id]/groups
+ * List all groups for a course, with member counts.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId } = await params;
+    const hasAccess = await canEditCourseWithRetry(session.user.id, courseId);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'You do not have permission to view this course' },
+        { status: 403 }
+      );
+    }
+
+    const groups = await withDatabaseRetry(async () => {
+      return prisma.course_groups.findMany({
+        where: { course_id: courseId },
+        orderBy: { created_at: 'asc' },
+        include: {
+          _count: { select: { memberships: true } },
+          creator: { select: { id: true, name: true, email: true } },
+        },
+      });
+    });
+
+    return NextResponse.json({
+      groups: groups.map((g) => ({
+        id: g.id,
+        name: g.name,
+        description: g.description,
+        canvasCourseId: g.canvas_course_id,
+        memberCount: g._count.memberships,
+        createdAt: g.created_at.toISOString(),
+        updatedAt: g.updated_at.toISOString(),
+        creator: g.creator,
+      })),
+    });
+  } catch (error) {
+    console.error('Error listing course groups:', error);
+    return NextResponse.json(
+      { error: 'Failed to list course groups' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/faculty/courses/[id]/groups
+ * Create a new group in a course.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId } = await params;
+    const hasAccess = await canEditCourseWithRetry(session.user.id, courseId);
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'You do not have permission to edit this course' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const { name, description, canvas_course_id } = createGroupSchema.parse(body);
+
+    // Check for duplicate name within this course (matches the unique constraint)
+    const existing = await withDatabaseRetry(async () => {
+      return prisma.course_groups.findFirst({
+        where: { course_id: courseId, name },
+        select: { id: true },
+      });
+    });
+    if (existing) {
+      return NextResponse.json(
+        { error: `A group named "${name}" already exists in this course` },
+        { status: 409 }
+      );
+    }
+
+    const group = await withDatabaseRetry(async () => {
+      return prisma.course_groups.create({
+        data: {
+          course_id: courseId,
+          name,
+          description: description || null,
+          canvas_course_id: canvas_course_id || null,
+          created_by: session.user.id,
+        },
+        include: {
+          _count: { select: { memberships: true } },
+          creator: { select: { id: true, name: true, email: true } },
+        },
+      });
+    });
+
+    return NextResponse.json({
+      group: {
+        id: group.id,
+        name: group.name,
+        description: group.description,
+        canvasCourseId: group.canvas_course_id,
+        memberCount: group._count.memberships,
+        createdAt: group.created_at.toISOString(),
+        updatedAt: group.updated_at.toISOString(),
+        creator: group.creator,
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation error', details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error('Error creating course group:', error);
+    return NextResponse.json(
+      { error: 'Failed to create course group' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/faculty/courses/[id]/quiz-export/route.ts
+++ b/src/app/api/faculty/courses/[id]/quiz-export/route.ts
@@ -62,6 +62,7 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const format = (searchParams.get('format') || 'xlsx').toLowerCase();
     const sheet = (searchParams.get('sheet') || 'quiz').toLowerCase();
+    const groupId = searchParams.get('groupId') || null;
 
     if (format !== 'xlsx' && format !== 'csv') {
       return NextResponse.json({ error: 'Invalid format' }, { status: 400 });
@@ -75,6 +76,29 @@ export async function GET(
         where: { id: courseId },
         select: { id: true, slug: true, title: true },
       });
+
+      // If groupId provided, verify it belongs to this course and collect
+      // the member user IDs to filter the enrolled-students query.
+      let group: { id: string; name: string } | null = null;
+      let groupMemberIds: string[] | null = null;
+      if (groupId) {
+        const g = await prisma.course_groups.findUnique({
+          where: { id: groupId },
+          select: {
+            id: true,
+            name: true,
+            course_id: true,
+            memberships: { select: { user_id: true } },
+          },
+        });
+        if (g && g.course_id === courseId) {
+          group = { id: g.id, name: g.name };
+          groupMemberIds = g.memberships.map((m) => m.user_id);
+        } else {
+          // Treat an invalid/cross-course groupId as a 404 below
+          return { course, courseModules: [], enrolledStudents: [], group: null, groupMemberIds: null, groupNotFound: true };
+        }
+      }
 
       // Get all modules in course with quizzes and submitted attempts
       const courseModules = await prisma.course_modules.findMany({
@@ -105,9 +129,12 @@ export async function GET(
         orderBy: { sort_order: 'asc' },
       });
 
-      // Get enrolled students
+      // Get enrolled students, optionally filtered to a group's member list
       const enrolledStudents = await prisma.course_tracking.findMany({
-        where: { course_id: courseId },
+        where: {
+          course_id: courseId,
+          ...(groupMemberIds !== null && { user_id: { in: groupMemberIds } }),
+        },
         include: {
           user: {
             select: { id: true, name: true, email: true },
@@ -115,11 +142,14 @@ export async function GET(
         },
       });
 
-      return { course, courseModules, enrolledStudents };
+      return { course, courseModules, enrolledStudents, group, groupMemberIds, groupNotFound: false };
     });
 
     if (!data.course) {
       return NextResponse.json({ error: 'Course not found' }, { status: 404 });
+    }
+    if (data.groupNotFound) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
     }
 
     const studentMap = new Map(data.enrolledStudents.map((e) => [e.user.id, e.user]));
@@ -283,6 +313,13 @@ export async function GET(
 
     const courseSlug = data.course.slug;
     const dateStr = new Date().toISOString().split('T')[0];
+    // Slugify the group name for the filename so it's safe on every filesystem
+    const groupSlug = data.group
+      ? `-${data.group.name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, '')}`
+      : '';
 
     if (format === 'xlsx') {
       const workbook = new ExcelJS.Workbook();
@@ -313,7 +350,7 @@ export async function GET(
         headers: {
           'Content-Type':
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-          'Content-Disposition': `attachment; filename="gradebook-${courseSlug}-${dateStr}.xlsx"`,
+          'Content-Disposition': `attachment; filename="gradebook-${courseSlug}${groupSlug}-${dateStr}.xlsx"`,
         },
       });
     }
@@ -331,7 +368,7 @@ export async function GET(
     return new NextResponse(csvContent, {
       headers: {
         'Content-Type': 'text/csv; charset=utf-8',
-        'Content-Disposition': `attachment; filename="gradebook-${courseSlug}-${sheet}-${dateStr}.csv"`,
+        'Content-Disposition': `attachment; filename="gradebook-${courseSlug}${groupSlug}-${sheet}-${dateStr}.csv"`,
       },
     });
   } catch (error) {

--- a/src/app/api/faculty/courses/[id]/quiz-export/route.ts
+++ b/src/app/api/faculty/courses/[id]/quiz-export/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth/config';
 import { prisma } from '@/lib/db';
 import { withDatabaseRetry } from '@/lib/retry';
 import { hasFacultyAccess } from '@/lib/auth/utils';
+import ExcelJS from 'exceljs';
 
 function escapeCSV(val: string): string {
   if (val.includes(',') || val.includes('"') || val.includes('\n')) {
@@ -11,9 +12,41 @@ function escapeCSV(val: string): string {
   return val;
 }
 
+const QUIZ_HEADERS = [
+  'Student Name',
+  'Student Email',
+  'Student ID',
+  'Module Title',
+  'Quiz Type',
+  'Quiz Title',
+  'Best Score %',
+  'Points Earned',
+  'Points Possible',
+  'Attempts Used',
+  'Passed',
+  'Last Attempt Date',
+];
+
+const GRADEBOOK_HEADERS = [
+  'Student Name',
+  'Student Email',
+  'Student ID',
+  'Overall Grade %',
+  'Total Points Earned',
+  'Total Points Possible',
+  'Quizzes Attempted',
+  'Quizzes Passed',
+  'Modules Completed',
+  'Modules Total',
+  'Last Activity',
+];
+
 /**
  * GET /api/faculty/courses/[id]/quiz-export
- * Enhanced CSV export with quiz_type and enrolled students
+ *
+ * Unified gradebook export. Returns either:
+ *  - format=xlsx (default): an .xlsx workbook with "Quiz Breakdown" and "Course Gradebook" sheets
+ *  - format=csv: a single-sheet CSV chosen via sheet=quiz|gradebook (default: quiz)
  */
 export async function GET(
   request: NextRequest,
@@ -26,9 +59,24 @@ export async function GET(
     }
 
     const { id: courseId } = await params;
+    const { searchParams } = new URL(request.url);
+    const format = (searchParams.get('format') || 'xlsx').toLowerCase();
+    const sheet = (searchParams.get('sheet') || 'quiz').toLowerCase();
+
+    if (format !== 'xlsx' && format !== 'csv') {
+      return NextResponse.json({ error: 'Invalid format' }, { status: 400 });
+    }
+    if (format === 'csv' && sheet !== 'quiz' && sheet !== 'gradebook') {
+      return NextResponse.json({ error: 'Invalid sheet' }, { status: 400 });
+    }
 
     const data = await withDatabaseRetry(async () => {
-      // Get all modules in course with quizzes (V2: plural relation)
+      const course = await prisma.courses.findUnique({
+        where: { id: courseId },
+        select: { id: true, slug: true, title: true },
+      });
+
+      // Get all modules in course with quizzes and submitted attempts
       const courseModules = await prisma.course_modules.findMany({
         where: { course_id: courseId },
         include: {
@@ -67,32 +115,22 @@ export async function GET(
         },
       });
 
-      return { courseModules, enrolledStudents };
+      return { course, courseModules, enrolledStudents };
     });
 
-    const studentMap = new Map(data.enrolledStudents.map(e => [e.user.id, e.user]));
+    if (!data.course) {
+      return NextResponse.json({ error: 'Course not found' }, { status: 404 });
+    }
 
-    const headers = [
-      'Student Name',
-      'Student Email',
-      'Student ID',
-      'Module Title',
-      'Quiz Type',
-      'Quiz Title',
-      'Best Score %',
-      'Points Earned',
-      'Points Possible',
-      'Attempts Used',
-      'Passed',
-      'Last Attempt Date',
-    ];
+    const studentMap = new Map(data.enrolledStudents.map((e) => [e.user.id, e.user]));
 
-    const rows: string[][] = [];
-
+    // Build quiz sheet rows (one row per student × quiz)
+    const quizRows: string[][] = [];
     for (const cm of data.courseModules) {
       const mod = cm.modules;
       for (const quiz of mod.quizzes) {
-        const quizTypeLabel = quiz.quiz_type === 'mastery_check' ? 'Mastery Check' : 'Assessment';
+        const quizTypeLabel =
+          quiz.quiz_type === 'mastery_check' ? 'Mastery Check' : 'Assessment';
 
         // Group attempts by user
         const attemptsByUser = new Map<string, typeof quiz.attempts>();
@@ -103,12 +141,11 @@ export async function GET(
           attemptsByUser.get(attempt.user_id)!.push(attempt);
         }
 
-        // Add row for each enrolled student
         for (const [userId, student] of studentMap) {
           const userAttempts = attemptsByUser.get(userId) || [];
 
           if (userAttempts.length === 0) {
-            rows.push([
+            quizRows.push([
               student.name,
               student.email,
               student.id,
@@ -130,7 +167,7 @@ export async function GET(
               new Date(a.submitted_at!) > new Date(last.submitted_at!) ? a : last
             );
 
-            rows.push([
+            quizRows.push([
               student.name,
               student.email,
               student.id,
@@ -151,16 +188,150 @@ export async function GET(
       }
     }
 
+    // Build gradebook sheet rows (one row per student)
+    // Strategy:
+    //   For each quiz in the course, determine its canonical points_possible by
+    //   looking at any submitted attempt (attempts for a given quiz should all
+    //   report the same points_possible; take the max to be safe). Quizzes with
+    //   zero attempts are excluded from the denominator since we cannot tell
+    //   their point value without an attempt record.
+    //   For each student, sum points_earned (best attempt per quiz, 0 if not
+    //   attempted) over all quizzes that contribute to the denominator.
+    type QuizInfo = {
+      id: string;
+      pointsPossible: number;
+      bestByUser: Map<string, { points: number; passed: boolean; submittedAt: Date | null }>;
+    };
+    const quizzesForGrade: QuizInfo[] = [];
+    for (const cm of data.courseModules) {
+      for (const quiz of cm.modules.quizzes) {
+        if (quiz.attempts.length === 0) continue;
+        let pointsPossible = 0;
+        const bestByUser = new Map<
+          string,
+          { points: number; passed: boolean; submittedAt: Date | null }
+        >();
+        for (const a of quiz.attempts) {
+          if (a.points_possible > pointsPossible) pointsPossible = a.points_possible;
+          const prev = bestByUser.get(a.user_id);
+          if (!prev || a.points_earned > prev.points) {
+            bestByUser.set(a.user_id, {
+              points: a.points_earned,
+              passed: a.passed,
+              submittedAt: a.submitted_at,
+            });
+          }
+        }
+        if (pointsPossible > 0) {
+          quizzesForGrade.push({ id: quiz.id, pointsPossible, bestByUser });
+        }
+      }
+    }
+
+    const enrollmentByUser = new Map(data.enrolledStudents.map((e) => [e.user.id, e]));
+
+    const gradebookRows: string[][] = [];
+    for (const [userId, student] of studentMap) {
+      const enrollment = enrollmentByUser.get(userId);
+      let totalEarned = 0;
+      let totalPossible = 0;
+      let attempted = 0;
+      let passed = 0;
+      let lastQuizSubmission: Date | null = null;
+
+      for (const q of quizzesForGrade) {
+        totalPossible += q.pointsPossible;
+        const best = q.bestByUser.get(userId);
+        if (best) {
+          totalEarned += best.points;
+          attempted += 1;
+          if (best.passed) passed += 1;
+          if (best.submittedAt && (!lastQuizSubmission || best.submittedAt > lastQuizSubmission)) {
+            lastQuizSubmission = best.submittedAt;
+          }
+        }
+      }
+
+      const overallGrade =
+        totalPossible > 0
+          ? (Math.round((totalEarned / totalPossible) * 1000) / 10).toFixed(1)
+          : 'N/A';
+
+      const lastActivityDate = (() => {
+        const candidates: Date[] = [];
+        if (enrollment?.last_accessed) candidates.push(new Date(enrollment.last_accessed));
+        if (lastQuizSubmission) candidates.push(lastQuizSubmission);
+        if (candidates.length === 0) return '';
+        const latest = candidates.reduce((a, b) => (a > b ? a : b));
+        return latest.toISOString().split('T')[0];
+      })();
+
+      gradebookRows.push([
+        student.name,
+        student.email,
+        student.id,
+        overallGrade,
+        totalEarned.toString(),
+        totalPossible.toString(),
+        attempted.toString(),
+        passed.toString(),
+        (enrollment?.modules_completed ?? 0).toString(),
+        (enrollment?.modules_total ?? 0).toString(),
+        lastActivityDate,
+      ]);
+    }
+
+    const courseSlug = data.course.slug;
+    const dateStr = new Date().toISOString().split('T')[0];
+
+    if (format === 'xlsx') {
+      const workbook = new ExcelJS.Workbook();
+      workbook.creator = 'BCS E-Textbook';
+      workbook.created = new Date();
+
+      const quizSheet = workbook.addWorksheet('Quiz Breakdown');
+      quizSheet.addRow(QUIZ_HEADERS);
+      for (const row of quizRows) quizSheet.addRow(row);
+      quizSheet.getRow(1).font = { bold: true };
+      quizSheet.views = [{ state: 'frozen', ySplit: 1 }];
+      quizSheet.columns.forEach((col) => {
+        col.width = 18;
+      });
+
+      const gradebookSheet = workbook.addWorksheet('Course Gradebook');
+      gradebookSheet.addRow(GRADEBOOK_HEADERS);
+      for (const row of gradebookRows) gradebookSheet.addRow(row);
+      gradebookSheet.getRow(1).font = { bold: true };
+      gradebookSheet.views = [{ state: 'frozen', ySplit: 1 }];
+      gradebookSheet.columns.forEach((col) => {
+        col.width = 18;
+      });
+
+      const buffer = await workbook.xlsx.writeBuffer();
+
+      return new NextResponse(buffer as ArrayBuffer, {
+        headers: {
+          'Content-Type':
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          'Content-Disposition': `attachment; filename="gradebook-${courseSlug}-${dateStr}.xlsx"`,
+        },
+      });
+    }
+
+    // CSV
+    const headers = sheet === 'gradebook' ? GRADEBOOK_HEADERS : QUIZ_HEADERS;
+    const rows = sheet === 'gradebook' ? gradebookRows : quizRows;
+
     const csvLines = [
       headers.map(escapeCSV).join(','),
-      ...rows.map(row => row.map(escapeCSV).join(',')),
+      ...rows.map((row) => row.map(escapeCSV).join(',')),
     ];
     const csvContent = csvLines.join('\n');
 
     return new NextResponse(csvContent, {
       headers: {
         'Content-Type': 'text/csv; charset=utf-8',
-        'Content-Disposition': `attachment; filename="quiz-grades-${courseId}.csv"`,
+        'Content-Disposition': `attachment; filename="gradebook-${courseSlug}-${sheet}-${dateStr}.csv"`,
       },
     });
   } catch (error) {

--- a/src/app/faculty/courses/[id]/groups/page.tsx
+++ b/src/app/faculty/courses/[id]/groups/page.tsx
@@ -1,0 +1,28 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth/config';
+import { hasFacultyAccess } from '@/lib/auth/utils';
+import { AuthenticatedLayout } from '@/components/layouts/app-layout';
+import { CourseGroupsManager } from '@/components/faculty/CourseGroupsManager';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function CourseGroupsPage({ params }: PageProps) {
+  const session = await auth();
+  const { id } = await params;
+
+  if (!session?.user) {
+    redirect('/auth/login');
+  }
+
+  if (!hasFacultyAccess(session)) {
+    redirect('/');
+  }
+
+  return (
+    <AuthenticatedLayout>
+      <CourseGroupsManager courseId={id} />
+    </AuthenticatedLayout>
+  );
+}

--- a/src/components/faculty/CourseGroupsManager.tsx
+++ b/src/components/faculty/CourseGroupsManager.tsx
@@ -1,0 +1,886 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { toast } from 'sonner';
+import {
+  ArrowLeft,
+  Plus,
+  Users,
+  Trash2,
+  Pencil,
+  UserPlus,
+  UserMinus,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { NeuralButton } from '@/components/ui/neural-button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+
+interface Group {
+  id: string;
+  name: string;
+  description: string | null;
+  canvasCourseId: string | null;
+  memberCount: number;
+  createdAt: string;
+  updatedAt: string;
+  creator: { id: string; name: string; email: string };
+}
+
+interface Member {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  avatarUrl: string | null;
+  role: string;
+  addedAt: string;
+}
+
+interface Enrollment {
+  userId: string;
+  name: string;
+  email: string;
+}
+
+type AddReportEntry = {
+  input: string;
+  status:
+    | 'added'
+    | 'already_in_group'
+    | 'already_in_other_group'
+    | 'not_enrolled'
+    | 'not_found'
+    | 'invalid_email';
+  userId?: string;
+  email?: string;
+  name?: string;
+  conflictGroupName?: string;
+};
+
+type AddReport = {
+  report: AddReportEntry[];
+  summary: {
+    added: number;
+    alreadyInGroup: number;
+    alreadyInOtherGroup: number;
+    notEnrolled: number;
+    notFound: number;
+    invalidEmail: number;
+  };
+};
+
+interface CourseGroupsManagerProps {
+  courseId: string;
+}
+
+export function CourseGroupsManager({ courseId }: CourseGroupsManagerProps) {
+  const [courseTitle, setCourseTitle] = useState<string>('');
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
+  const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
+  const [membersByGroup, setMembersByGroup] = useState<Record<string, Member[]>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Dialog state
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<Group | null>(null);
+  const [addMembersGroup, setAddMembersGroup] = useState<Group | null>(null);
+  const [deleteGroup, setDeleteGroup] = useState<Group | null>(null);
+
+  // Fetch course title for breadcrumb
+  useEffect(() => {
+    fetch(`/api/courses/${courseId}`)
+      .then((r) => r.json())
+      .then((d) => setCourseTitle(d?.course?.title || ''))
+      .catch(() => {});
+  }, [courseId]);
+
+  const fetchGroups = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/faculty/courses/${courseId}/groups`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to load groups');
+      setGroups(data.groups);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load groups');
+    }
+  }, [courseId]);
+
+  const fetchEnrollments = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/faculty/courses/${courseId}/students`);
+      const data = await res.json();
+      if (!res.ok) return;
+      setEnrollments(
+        (data.learners || []).map((l: { learner: { id: string; name: string; email: string } }) => ({
+          userId: l.learner.id,
+          name: l.learner.name,
+          email: l.learner.email,
+        }))
+      );
+    } catch {
+      // Non-fatal: enrollments used only for the picker
+    }
+  }, [courseId]);
+
+  useEffect(() => {
+    Promise.all([fetchGroups(), fetchEnrollments()]).finally(() => setIsLoading(false));
+  }, [fetchGroups, fetchEnrollments]);
+
+  const fetchMembers = useCallback(
+    async (groupId: string) => {
+      const res = await fetch(`/api/faculty/courses/${courseId}/groups/${groupId}/members`);
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to load members');
+        return;
+      }
+      setMembersByGroup((prev) => ({ ...prev, [groupId]: data.members }));
+    },
+    [courseId]
+  );
+
+  const toggleExpand = (groupId: string) => {
+    if (expandedGroupId === groupId) {
+      setExpandedGroupId(null);
+      return;
+    }
+    setExpandedGroupId(groupId);
+    if (!membersByGroup[groupId]) {
+      fetchMembers(groupId);
+    }
+  };
+
+  const removeMember = async (groupId: string, userId: string) => {
+    const res = await fetch(
+      `/api/faculty/courses/${courseId}/groups/${groupId}/members/${userId}`,
+      { method: 'DELETE' }
+    );
+    if (!res.ok) {
+      const data = await res.json();
+      toast.error(data.error || 'Failed to remove member');
+      return;
+    }
+    toast.success('Member removed');
+    fetchMembers(groupId);
+    fetchGroups(); // refresh counts
+  };
+
+  const confirmDeleteGroup = async () => {
+    if (!deleteGroup) return;
+    const res = await fetch(
+      `/api/faculty/courses/${courseId}/groups/${deleteGroup.id}`,
+      { method: 'DELETE' }
+    );
+    if (!res.ok) {
+      const data = await res.json();
+      toast.error(data.error || 'Failed to delete group');
+      return;
+    }
+    toast.success(`Deleted group "${deleteGroup.name}"`);
+    setDeleteGroup(null);
+    setExpandedGroupId(null);
+    fetchGroups();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading groups...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center gap-2 text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-5xl">
+      {/* Header */}
+      <div className="mb-6">
+        <Link
+          href={`/faculty/courses/edit/${courseId}`}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-3"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to course
+        </Link>
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Course Groups</h1>
+            {courseTitle && (
+              <p className="text-muted-foreground mt-1">{courseTitle}</p>
+            )}
+            <p className="text-sm text-muted-foreground mt-2 max-w-2xl">
+              Organize enrolled students into groups (e.g. one group per section).
+              Groups let you filter gradebook exports and map to a specific Canvas
+              course when syncing grades.
+            </p>
+          </div>
+          <NeuralButton variant="neural" onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            Create Group
+          </NeuralButton>
+        </div>
+      </div>
+
+      {/* Empty state */}
+      {groups.length === 0 && (
+        <Card className="cognitive-card">
+          <CardContent className="p-12 text-center">
+            <Users className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <h3 className="text-lg font-medium mb-1">No groups yet</h3>
+            <p className="text-sm text-muted-foreground mb-4">
+              Create a group to organize a subset of enrolled students.
+            </p>
+            <NeuralButton variant="neural" onClick={() => setCreateOpen(true)}>
+              <Plus className="h-4 w-4 mr-1" />
+              Create your first group
+            </NeuralButton>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Group list */}
+      <div className="space-y-3">
+        {groups.map((group) => {
+          const isExpanded = expandedGroupId === group.id;
+          const members = membersByGroup[group.id] || [];
+          return (
+            <Card key={group.id} className="cognitive-card">
+              <CardHeader
+                className="cursor-pointer hover:bg-muted/30 transition-colors"
+                onClick={() => toggleExpand(group.id)}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-start gap-3 flex-1 min-w-0">
+                    {isExpanded ? (
+                      <ChevronDown className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
+                    ) : (
+                      <ChevronRight className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <CardTitle className="text-lg">{group.name}</CardTitle>
+                      {group.description && (
+                        <p className="text-sm text-muted-foreground mt-1">
+                          {group.description}
+                        </p>
+                      )}
+                      <div className="flex items-center gap-2 mt-2 flex-wrap">
+                        <Badge variant="secondary">
+                          <Users className="h-3 w-3 mr-1" />
+                          {group.memberCount} member{group.memberCount === 1 ? '' : 's'}
+                        </Badge>
+                        {group.canvasCourseId && (
+                          <Badge variant="outline">
+                            Canvas: {group.canvasCourseId}
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                    <NeuralButton
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setEditingGroup(group)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </NeuralButton>
+                    <NeuralButton
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteGroup(group)}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </NeuralButton>
+                  </div>
+                </div>
+              </CardHeader>
+
+              {isExpanded && (
+                <CardContent className="border-t border-border/40">
+                  <div className="flex items-center justify-between mb-3 mt-4">
+                    <h4 className="font-medium">Members</h4>
+                    <NeuralButton
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setAddMembersGroup(group)}
+                    >
+                      <UserPlus className="h-4 w-4 mr-1" />
+                      Add Members
+                    </NeuralButton>
+                  </div>
+                  {members.length === 0 ? (
+                    <p className="text-sm text-muted-foreground py-4 text-center">
+                      No members yet. Click &quot;Add Members&quot; to get started.
+                    </p>
+                  ) : (
+                    <div className="space-y-1">
+                      {members.map((m) => (
+                        <div
+                          key={m.id}
+                          className="flex items-center justify-between p-2 rounded-md hover:bg-muted/30"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium truncate">{m.name}</div>
+                            <div className="text-xs text-muted-foreground truncate">
+                              {m.email}
+                            </div>
+                          </div>
+                          <NeuralButton
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => removeMember(group.id, m.userId)}
+                          >
+                            <UserMinus className="h-4 w-4 text-destructive" />
+                          </NeuralButton>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              )}
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* Create group dialog */}
+      <GroupFormDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        mode="create"
+        courseId={courseId}
+        onSaved={fetchGroups}
+      />
+
+      {/* Edit group dialog */}
+      <GroupFormDialog
+        open={!!editingGroup}
+        onOpenChange={(open) => !open && setEditingGroup(null)}
+        mode="edit"
+        courseId={courseId}
+        group={editingGroup}
+        onSaved={fetchGroups}
+      />
+
+      {/* Add members dialog */}
+      <AddMembersDialog
+        open={!!addMembersGroup}
+        onOpenChange={(open) => !open && setAddMembersGroup(null)}
+        courseId={courseId}
+        group={addMembersGroup}
+        enrollments={enrollments}
+        existingMemberIds={
+          addMembersGroup ? (membersByGroup[addMembersGroup.id] || []).map((m) => m.userId) : []
+        }
+        onAdded={() => {
+          if (addMembersGroup) {
+            fetchMembers(addMembersGroup.id);
+            fetchGroups();
+          }
+        }}
+      />
+
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        open={!!deleteGroup}
+        onOpenChange={(open) => !open && setDeleteGroup(null)}
+        title={`Delete group "${deleteGroup?.name}"?`}
+        description={`This will remove all ${deleteGroup?.memberCount || 0} membership(s). Students stay enrolled in the course.`}
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={confirmDeleteGroup}
+      />
+    </div>
+  );
+}
+
+// ============================================================================
+// Create/Edit group form dialog
+// ============================================================================
+
+interface GroupFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: 'create' | 'edit';
+  courseId: string;
+  group?: Group | null;
+  onSaved: () => void;
+}
+
+function GroupFormDialog({
+  open,
+  onOpenChange,
+  mode,
+  courseId,
+  group,
+  onSaved,
+}: GroupFormDialogProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [canvasCourseId, setCanvasCourseId] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName(group?.name || '');
+      setDescription(group?.description || '');
+      setCanvasCourseId(group?.canvasCourseId || '');
+    }
+  }, [open, group]);
+
+  const save = async () => {
+    if (!name.trim()) {
+      toast.error('Name is required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const url =
+        mode === 'create'
+          ? `/api/faculty/courses/${courseId}/groups`
+          : `/api/faculty/courses/${courseId}/groups/${group!.id}`;
+      const method = mode === 'create' ? 'POST' : 'PATCH';
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim() || null,
+          canvas_course_id: canvasCourseId.trim() || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to save group');
+        return;
+      }
+      toast.success(mode === 'create' ? 'Group created' : 'Group updated');
+      onSaved();
+      onOpenChange(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {mode === 'create' ? 'Create Group' : 'Edit Group'}
+          </DialogTitle>
+          <DialogDescription>
+            Groups let you scope gradebook exports and Canvas grade sync to a
+            specific subset of enrolled students.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1">
+            <Label htmlFor="group-name">Name *</Label>
+            <Input
+              id="group-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Spring 2026 Section A"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="group-description">Description</Label>
+            <Textarea
+              id="group-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional notes about this group"
+              rows={2}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="group-canvas">Canvas Course ID</Label>
+            <Input
+              id="group-canvas"
+              value={canvasCourseId}
+              onChange={(e) => setCanvasCourseId(e.target.value)}
+              placeholder="Numeric Canvas course ID (optional)"
+            />
+            <p className="text-xs text-muted-foreground">
+              Used later when syncing grades to Canvas. You can leave blank for now.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <NeuralButton variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </NeuralButton>
+          <NeuralButton variant="neural" onClick={save} disabled={saving}>
+            {saving ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : null}
+            {mode === 'create' ? 'Create' : 'Save'}
+          </NeuralButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ============================================================================
+// Add members dialog — supports picker + bulk email paste
+// ============================================================================
+
+interface AddMembersDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  courseId: string;
+  group: Group | null;
+  enrollments: Enrollment[];
+  existingMemberIds: string[];
+  onAdded: () => void;
+}
+
+function AddMembersDialog({
+  open,
+  onOpenChange,
+  courseId,
+  group,
+  enrollments,
+  existingMemberIds,
+  onAdded,
+}: AddMembersDialogProps) {
+  const [tab, setTab] = useState<'picker' | 'bulk'>('picker');
+  const [pickerSearch, setPickerSearch] = useState('');
+  const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(new Set());
+  const [bulkText, setBulkText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [report, setReport] = useState<AddReport | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setPickerSearch('');
+      setSelectedUserIds(new Set());
+      setBulkText('');
+      setReport(null);
+      setTab('picker');
+    }
+  }, [open]);
+
+  if (!group) return null;
+
+  const existingSet = new Set(existingMemberIds);
+  const filteredEnrollments = enrollments.filter((e) => {
+    if (existingSet.has(e.userId)) return false; // already in this group
+    const q = pickerSearch.trim().toLowerCase();
+    if (!q) return true;
+    return (
+      e.name.toLowerCase().includes(q) || e.email.toLowerCase().includes(q)
+    );
+  });
+
+  const toggle = (userId: string) => {
+    setSelectedUserIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  };
+
+  const submit = async () => {
+    let payload: { userIds?: string[]; emails?: string[] };
+    if (tab === 'picker') {
+      if (selectedUserIds.size === 0) {
+        toast.error('Select at least one student');
+        return;
+      }
+      payload = { userIds: Array.from(selectedUserIds) };
+    } else {
+      // Split pasted text on commas, whitespace, newlines
+      const emails = bulkText
+        .split(/[\s,;]+/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (emails.length === 0) {
+        toast.error('Paste at least one email');
+        return;
+      }
+      payload = { emails };
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `/api/faculty/courses/${courseId}/groups/${group.id}/members`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error || 'Failed to add members');
+        return;
+      }
+      setReport(data);
+      if (data.summary.added > 0) {
+        toast.success(`Added ${data.summary.added} member(s)`);
+        onAdded();
+      }
+      // Don't auto-close — let faculty see the report
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Add Members to &quot;{group.name}&quot;</DialogTitle>
+          <DialogDescription>
+            Pick from enrolled students or paste a list of emails. Only students
+            already enrolled in this course can be added.
+          </DialogDescription>
+        </DialogHeader>
+
+        {report ? (
+          <ReportView report={report} onDone={() => onOpenChange(false)} onAddMore={() => setReport(null)} />
+        ) : (
+          <>
+            <Tabs value={tab} onValueChange={(v) => setTab(v as 'picker' | 'bulk')}>
+              <TabsList className="grid grid-cols-2 w-full">
+                <TabsTrigger value="picker">Pick Enrolled</TabsTrigger>
+                <TabsTrigger value="bulk">Paste Emails</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="picker" className="space-y-3">
+                <Input
+                  placeholder="Search by name or email..."
+                  value={pickerSearch}
+                  onChange={(e) => setPickerSearch(e.target.value)}
+                />
+                <div className="border border-border/40 rounded-md max-h-[300px] overflow-y-auto">
+                  {filteredEnrollments.length === 0 ? (
+                    <p className="text-sm text-muted-foreground p-4 text-center">
+                      {enrollments.length === 0
+                        ? 'No enrolled students found.'
+                        : 'No matching students (all enrolled students may already be in this group).'}
+                    </p>
+                  ) : (
+                    filteredEnrollments.map((e) => (
+                      <label
+                        key={e.userId}
+                        className="flex items-center gap-3 p-3 hover:bg-muted/30 cursor-pointer border-b border-border/20 last:border-b-0"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedUserIds.has(e.userId)}
+                          onChange={() => toggle(e.userId)}
+                          className="h-4 w-4"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm font-medium truncate">{e.name}</div>
+                          <div className="text-xs text-muted-foreground truncate">{e.email}</div>
+                        </div>
+                      </label>
+                    ))
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {selectedUserIds.size} selected
+                </p>
+              </TabsContent>
+
+              <TabsContent value="bulk" className="space-y-3">
+                <Label htmlFor="bulk-emails">
+                  Paste emails (comma, space, or newline separated)
+                </Label>
+                <Textarea
+                  id="bulk-emails"
+                  value={bulkText}
+                  onChange={(e) => setBulkText(e.target.value)}
+                  placeholder="student1@illinois.edu&#10;student2@illinois.edu&#10;student3@illinois.edu"
+                  rows={8}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Students must already be enrolled in this course. You&apos;ll see
+                  a report showing exactly what happened for each email.
+                </p>
+              </TabsContent>
+            </Tabs>
+
+            <DialogFooter>
+              <NeuralButton variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+                Cancel
+              </NeuralButton>
+              <NeuralButton variant="neural" onClick={submit} disabled={submitting}>
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : <UserPlus className="h-4 w-4 mr-1" />}
+                Add Members
+              </NeuralButton>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ============================================================================
+// Bulk-add result report
+// ============================================================================
+
+function ReportView({
+  report,
+  onDone,
+  onAddMore,
+}: {
+  report: AddReport;
+  onDone: () => void;
+  onAddMore: () => void;
+}) {
+  const { summary, report: entries } = report;
+
+  const statusConfig: Record<
+    AddReportEntry['status'],
+    { label: string; color: string }
+  > = {
+    added: { label: 'Added', color: 'text-green-600 dark:text-green-400' },
+    already_in_group: { label: 'Already in this group', color: 'text-muted-foreground' },
+    already_in_other_group: {
+      label: 'In another group',
+      color: 'text-amber-600 dark:text-amber-400',
+    },
+    not_enrolled: {
+      label: 'Not enrolled in course',
+      color: 'text-red-600 dark:text-red-400',
+    },
+    not_found: { label: 'User not found', color: 'text-red-600 dark:text-red-400' },
+    invalid_email: { label: 'Invalid email', color: 'text-red-600 dark:text-red-400' },
+  };
+
+  return (
+    <>
+      <div className="py-4">
+        <div className="flex items-center gap-2 mb-4">
+          <CheckCircle2 className="h-5 w-5 text-green-600" />
+          <h3 className="font-medium">Results</h3>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4 text-sm">
+          <SummaryStat label="Added" value={summary.added} good />
+          {summary.alreadyInGroup > 0 && (
+            <SummaryStat label="Already in group" value={summary.alreadyInGroup} />
+          )}
+          {summary.alreadyInOtherGroup > 0 && (
+            <SummaryStat label="In other group" value={summary.alreadyInOtherGroup} warn />
+          )}
+          {summary.notEnrolled > 0 && (
+            <SummaryStat label="Not enrolled" value={summary.notEnrolled} bad />
+          )}
+          {summary.notFound > 0 && (
+            <SummaryStat label="Not found" value={summary.notFound} bad />
+          )}
+          {summary.invalidEmail > 0 && (
+            <SummaryStat label="Invalid email" value={summary.invalidEmail} bad />
+          )}
+        </div>
+
+        <div className="border border-border/40 rounded-md max-h-[300px] overflow-y-auto">
+          {entries.map((entry, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between gap-3 p-2 border-b border-border/20 last:border-b-0 text-sm"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium">
+                  {entry.name || entry.email || entry.input}
+                </div>
+                {entry.name && entry.email && (
+                  <div className="text-xs text-muted-foreground truncate">
+                    {entry.email}
+                  </div>
+                )}
+              </div>
+              <div className={`text-xs font-medium ${statusConfig[entry.status].color}`}>
+                {statusConfig[entry.status].label}
+                {entry.conflictGroupName && (
+                  <span className="block text-[10px] text-muted-foreground">
+                    in &quot;{entry.conflictGroupName}&quot;
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <DialogFooter>
+        <NeuralButton variant="outline" onClick={onAddMore}>
+          Add more
+        </NeuralButton>
+        <NeuralButton variant="neural" onClick={onDone}>
+          Done
+        </NeuralButton>
+      </DialogFooter>
+    </>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  good,
+  warn,
+  bad,
+}: {
+  label: string;
+  value: number;
+  good?: boolean;
+  warn?: boolean;
+  bad?: boolean;
+}) {
+  const color = good
+    ? 'text-green-600 dark:text-green-400'
+    : warn
+      ? 'text-amber-600 dark:text-amber-400'
+      : bad
+        ? 'text-red-600 dark:text-red-400'
+        : 'text-muted-foreground';
+  return (
+    <div className="border border-border/40 rounded-md p-2">
+      <div className={`text-xl font-bold ${color}`}>{value}</div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+    </div>
+  );
+}

--- a/src/components/faculty/CourseGroupsManager.tsx
+++ b/src/components/faculty/CourseGroupsManager.tsx
@@ -31,7 +31,6 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 interface Group {
@@ -680,13 +679,30 @@ function AddMembersDialog({
           <ReportView report={report} onDone={() => onOpenChange(false)} onAddMore={() => setReport(null)} />
         ) : (
           <>
-            <Tabs value={tab} onValueChange={(v) => setTab(v as 'picker' | 'bulk')}>
-              <TabsList className="grid grid-cols-2 w-full">
-                <TabsTrigger value="picker">Pick Enrolled</TabsTrigger>
-                <TabsTrigger value="bulk">Paste Emails</TabsTrigger>
-              </TabsList>
+            <div className="border-b border-border mb-4">
+              <nav className="flex gap-6 sm:gap-8">
+                {([
+                  { key: 'picker', label: 'Pick Enrolled' },
+                  { key: 'bulk', label: 'Paste Emails' },
+                ] as const).map(({ key, label }) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setTab(key)}
+                    className={`py-2.5 sm:py-3 px-1 border-b-2 font-medium text-xs sm:text-sm transition-colors whitespace-nowrap ${
+                      tab === key
+                        ? 'border-blue-600 text-blue-600'
+                        : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </nav>
+            </div>
 
-              <TabsContent value="picker" className="space-y-3">
+            {tab === 'picker' && (
+              <div className="space-y-3">
                 <Input
                   placeholder="Search by name or email..."
                   value={pickerSearch}
@@ -722,9 +738,11 @@ function AddMembersDialog({
                 <p className="text-xs text-muted-foreground">
                   {selectedUserIds.size} selected
                 </p>
-              </TabsContent>
+              </div>
+            )}
 
-              <TabsContent value="bulk" className="space-y-3">
+            {tab === 'bulk' && (
+              <div className="space-y-3">
                 <Label htmlFor="bulk-emails">
                   Paste emails (comma, space, or newline separated)
                 </Label>
@@ -739,8 +757,8 @@ function AddMembersDialog({
                   Students must already be enrolled in this course. You&apos;ll see
                   a report showing exactly what happened for each email.
                 </p>
-              </TabsContent>
-            </Tabs>
+              </div>
+            )}
 
             <DialogFooter>
               <NeuralButton variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>

--- a/src/components/faculty/analytics/CourseAnalyticsDashboard.tsx
+++ b/src/components/faculty/analytics/CourseAnalyticsDashboard.tsx
@@ -17,6 +17,19 @@ import {
 import { ArrowLeft, Users, TrendingUp, Award, Activity } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { QuizExportButton } from '@/components/quiz/QuizExportButton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface Group {
+  id: string;
+  name: string;
+  memberCount: number;
+}
 
 interface AnalyticsData {
   courseTitle: string;
@@ -54,12 +67,37 @@ export default function CourseAnalyticsDashboard({ courseId }: CourseAnalyticsDa
   const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('all');
 
+  // Fetch groups once on mount so the picker can be populated
+  useEffect(() => {
+    const fetchGroups = async () => {
+      try {
+        const response = await fetch(`/api/faculty/courses/${courseId}/groups`);
+        if (!response.ok) return;
+        const data = await response.json();
+        setGroups(data.groups || []);
+      } catch {
+        // Non-fatal — picker just stays empty
+      }
+    };
+    fetchGroups();
+  }, [courseId]);
+
+  // Re-fetch analytics whenever the course or selected group changes
   useEffect(() => {
     const fetchAnalytics = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`/api/faculty/analytics/${courseId}`);
+        const params = new URLSearchParams();
+        if (selectedGroupId && selectedGroupId !== 'all') {
+          params.set('groupId', selectedGroupId);
+        }
+        const qs = params.toString();
+        const response = await fetch(
+          `/api/faculty/analytics/${courseId}${qs ? `?${qs}` : ''}`
+        );
 
         if (!response.ok) {
           const errorData = await response.json();
@@ -76,9 +114,9 @@ export default function CourseAnalyticsDashboard({ courseId }: CourseAnalyticsDa
     };
 
     fetchAnalytics();
-  }, [courseId]);
+  }, [courseId, selectedGroupId]);
 
-  if (loading) {
+  if (loading && !analytics) {
     return (
       <div className="container mx-auto px-4 sm:px-6 py-6 sm:py-8 flex items-center justify-center min-h-[400px]">
         <div className="text-muted-foreground text-lg">Loading analytics...</div>
@@ -127,7 +165,22 @@ export default function CourseAnalyticsDashboard({ courseId }: CourseAnalyticsDa
             <Users className="w-4 h-4" />
             Groups
           </Link>
-          <QuizExportButton courseId={courseId} />
+          {groups.length > 0 && (
+            <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
+              <SelectTrigger className="h-9 w-[200px] text-sm">
+                <SelectValue placeholder="Filter by group" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All enrolled students</SelectItem>
+                {groups.map((group) => (
+                  <SelectItem key={group.id} value={group.id}>
+                    {group.name} ({group.memberCount})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <QuizExportButton courseId={courseId} groupId={selectedGroupId} />
         </div>
       </div>
 

--- a/src/components/faculty/analytics/CourseAnalyticsDashboard.tsx
+++ b/src/components/faculty/analytics/CourseAnalyticsDashboard.tsx
@@ -119,7 +119,16 @@ export default function CourseAnalyticsDashboard({ courseId }: CourseAnalyticsDa
           <h1 className="text-3xl font-bold text-neural-primary">{analytics.courseTitle}</h1>
           <p className="text-muted-foreground mt-2">Course Analytics Dashboard</p>
         </div>
-        <QuizExportButton courseId={courseId} />
+        <div className="flex items-center gap-2 flex-wrap">
+          <Link
+            href={`/faculty/courses/${courseId}/groups`}
+            className="inline-flex items-center gap-1 px-3 h-9 text-sm rounded-md border border-border/60 hover:bg-muted/50 transition-colors"
+          >
+            <Users className="w-4 h-4" />
+            Groups
+          </Link>
+          <QuizExportButton courseId={courseId} />
+        </div>
       </div>
 
       {/* Stats Cards */}

--- a/src/components/quiz/QuizExportButton.tsx
+++ b/src/components/quiz/QuizExportButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { NeuralButton } from '@/components/ui/neural-button';
 import {
   DropdownMenu,
@@ -18,10 +18,23 @@ import {
 } from '@/components/ui/dialog';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
-import { Download, Loader2, ChevronDown } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Download, Loader2, ChevronDown, Users } from 'lucide-react';
 import { toast } from 'sonner';
 
 type CsvSheet = 'quiz' | 'gradebook';
+
+interface Group {
+  id: string;
+  name: string;
+  memberCount: number;
+}
 
 interface QuizExportButtonProps {
   courseId: string;
@@ -31,12 +44,31 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
   const [loading, setLoading] = useState(false);
   const [csvDialogOpen, setCsvDialogOpen] = useState(false);
   const [csvSheet, setCsvSheet] = useState<CsvSheet>('gradebook');
+  const [groups, setGroups] = useState<Group[]>([]);
+  // "all" sentinel means export every enrolled student (no group filter)
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('all');
+
+  // Fetch groups on mount so the picker can show them. Non-fatal if it fails
+  // — faculty can still export "all enrolled" and the select just stays hidden.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/faculty/courses/${courseId}/groups`)
+      .then((res) => (res.ok ? res.json() : { groups: [] }))
+      .then((data) => {
+        if (!cancelled) setGroups(data.groups || []);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
 
   const download = async (format: 'xlsx' | 'csv', sheet?: CsvSheet) => {
     setLoading(true);
     try {
       const params = new URLSearchParams({ format });
       if (format === 'csv' && sheet) params.set('sheet', sheet);
+      if (selectedGroupId !== 'all') params.set('groupId', selectedGroupId);
 
       const res = await fetch(
         `/api/faculty/courses/${courseId}/quiz-export?${params.toString()}`
@@ -74,7 +106,25 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
   };
 
   return (
-    <>
+    <div className="flex items-center gap-2">
+      {/* Group picker — only shown when the course has at least one group */}
+      {groups.length > 0 && (
+        <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
+          <SelectTrigger className="h-9 w-auto min-w-[180px]">
+            <Users className="h-4 w-4 mr-1 text-muted-foreground" />
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All enrolled students</SelectItem>
+            {groups.map((g) => (
+              <SelectItem key={g.id} value={g.id}>
+                {g.name} ({g.memberCount})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <NeuralButton variant="outline" size="sm" disabled={loading}>
@@ -170,6 +220,6 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </>
+    </div>
   );
 }

--- a/src/components/quiz/QuizExportButton.tsx
+++ b/src/components/quiz/QuizExportButton.tsx
@@ -92,7 +92,7 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
             <div className="flex flex-col">
               <span className="font-medium">Excel (.xlsx)</span>
               <span className="text-xs text-muted-foreground">
-                Both sheets in one file
+                Course gradebook + quiz-by-quiz breakdown
               </span>
             </div>
           </DropdownMenuItem>
@@ -100,7 +100,7 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
             <div className="flex flex-col">
               <span className="font-medium">CSV</span>
               <span className="text-xs text-muted-foreground">
-                Choose a single sheet
+                Gradebook or quiz breakdown (pick one)
               </span>
             </div>
           </DropdownMenuItem>

--- a/src/components/quiz/QuizExportButton.tsx
+++ b/src/components/quiz/QuizExportButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { NeuralButton } from '@/components/ui/neural-button';
 import {
   DropdownMenu,
@@ -18,57 +18,32 @@ import {
 } from '@/components/ui/dialog';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Download, Loader2, ChevronDown, Users } from 'lucide-react';
+import { Download, Loader2, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 
 type CsvSheet = 'quiz' | 'gradebook';
 
-interface Group {
-  id: string;
-  name: string;
-  memberCount: number;
-}
-
 interface QuizExportButtonProps {
   courseId: string;
+  /**
+   * Group id to scope the export to. "all" (or undefined) exports every
+   * enrolled student. The picker itself lives in the parent now so analytics
+   * and export stay in sync.
+   */
+  groupId?: string;
 }
 
-export function QuizExportButton({ courseId }: QuizExportButtonProps) {
+export function QuizExportButton({ courseId, groupId = 'all' }: QuizExportButtonProps) {
   const [loading, setLoading] = useState(false);
   const [csvDialogOpen, setCsvDialogOpen] = useState(false);
   const [csvSheet, setCsvSheet] = useState<CsvSheet>('gradebook');
-  const [groups, setGroups] = useState<Group[]>([]);
-  // "all" sentinel means export every enrolled student (no group filter)
-  const [selectedGroupId, setSelectedGroupId] = useState<string>('all');
-
-  // Fetch groups on mount so the picker can show them. Non-fatal if it fails
-  // — faculty can still export "all enrolled" and the select just stays hidden.
-  useEffect(() => {
-    let cancelled = false;
-    fetch(`/api/faculty/courses/${courseId}/groups`)
-      .then((res) => (res.ok ? res.json() : { groups: [] }))
-      .then((data) => {
-        if (!cancelled) setGroups(data.groups || []);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [courseId]);
 
   const download = async (format: 'xlsx' | 'csv', sheet?: CsvSheet) => {
     setLoading(true);
     try {
       const params = new URLSearchParams({ format });
       if (format === 'csv' && sheet) params.set('sheet', sheet);
-      if (selectedGroupId !== 'all') params.set('groupId', selectedGroupId);
+      if (groupId && groupId !== 'all') params.set('groupId', groupId);
 
       const res = await fetch(
         `/api/faculty/courses/${courseId}/quiz-export?${params.toString()}`
@@ -106,25 +81,7 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
   };
 
   return (
-    <div className="flex items-center gap-2">
-      {/* Group picker — only shown when the course has at least one group */}
-      {groups.length > 0 && (
-        <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
-          <SelectTrigger className="h-9 w-auto min-w-[180px]">
-            <Users className="h-4 w-4 mr-1 text-muted-foreground" />
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All enrolled students</SelectItem>
-            {groups.map((g) => (
-              <SelectItem key={g.id} value={g.id}>
-                {g.name} ({g.memberCount})
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
-
+    <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <NeuralButton variant="outline" size="sm" disabled={loading}>
@@ -220,6 +177,6 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </>
   );
 }

--- a/src/components/quiz/QuizExportButton.tsx
+++ b/src/components/quiz/QuizExportButton.tsx
@@ -2,8 +2,26 @@
 
 import { useState } from 'react';
 import { NeuralButton } from '@/components/ui/neural-button';
-import { Download, Loader2 } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { Download, Loader2, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
+
+type CsvSheet = 'quiz' | 'gradebook';
 
 interface QuizExportButtonProps {
   courseId: string;
@@ -11,27 +29,43 @@ interface QuizExportButtonProps {
 
 export function QuizExportButton({ courseId }: QuizExportButtonProps) {
   const [loading, setLoading] = useState(false);
+  const [csvDialogOpen, setCsvDialogOpen] = useState(false);
+  const [csvSheet, setCsvSheet] = useState<CsvSheet>('gradebook');
 
-  const handleExport = async () => {
+  const download = async (format: 'xlsx' | 'csv', sheet?: CsvSheet) => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/faculty/courses/${courseId}/quiz-export`);
+      const params = new URLSearchParams({ format });
+      if (format === 'csv' && sheet) params.set('sheet', sheet);
+
+      const res = await fetch(
+        `/api/faculty/courses/${courseId}/quiz-export?${params.toString()}`
+      );
       if (!res.ok) {
         toast.error('Failed to export grades');
         return;
       }
 
       const blob = await res.blob();
+
+      // Try to pull filename from Content-Disposition, fall back to a default
+      const disposition = res.headers.get('Content-Disposition') || '';
+      const match = disposition.match(/filename="([^"]+)"/);
+      const filename =
+        match?.[1] ||
+        `gradebook-${courseId}.${format === 'xlsx' ? 'xlsx' : 'csv'}`;
+
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = `quiz-grades-${courseId}.csv`;
+      link.download = filename;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
 
       toast.success('Grades exported successfully');
+      setCsvDialogOpen(false);
     } catch {
       toast.error('Failed to export grades');
     } finally {
@@ -40,18 +74,102 @@ export function QuizExportButton({ courseId }: QuizExportButtonProps) {
   };
 
   return (
-    <NeuralButton
-      variant="outline"
-      size="sm"
-      onClick={handleExport}
-      disabled={loading}
-    >
-      {loading ? (
-        <Loader2 className="h-4 w-4 animate-spin mr-1" />
-      ) : (
-        <Download className="h-4 w-4 mr-1" />
-      )}
-      Export Quiz Grades (CSV)
-    </NeuralButton>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <NeuralButton variant="outline" size="sm" disabled={loading}>
+            {loading ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-1" />
+            ) : (
+              <Download className="h-4 w-4 mr-1" />
+            )}
+            Export Grades
+            <ChevronDown className="h-4 w-4 ml-1" />
+          </NeuralButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuItem onClick={() => download('xlsx')}>
+            <div className="flex flex-col">
+              <span className="font-medium">Excel (.xlsx)</span>
+              <span className="text-xs text-muted-foreground">
+                Both sheets in one file
+              </span>
+            </div>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setCsvDialogOpen(true)}>
+            <div className="flex flex-col">
+              <span className="font-medium">CSV</span>
+              <span className="text-xs text-muted-foreground">
+                Choose a single sheet
+              </span>
+            </div>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={csvDialogOpen} onOpenChange={setCsvDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Export as CSV</DialogTitle>
+            <DialogDescription>
+              CSV files can only contain one sheet. Choose which one to download.
+            </DialogDescription>
+          </DialogHeader>
+
+          <RadioGroup
+            value={csvSheet}
+            onValueChange={(v) => setCsvSheet(v as CsvSheet)}
+            className="gap-3 py-2"
+          >
+            <div className="flex items-start space-x-3 p-3 rounded-lg border border-border/40 hover:bg-muted/30 transition-colors">
+              <RadioGroupItem value="gradebook" id="csv-gradebook" className="mt-0.5" />
+              <div className="flex-1">
+                <Label htmlFor="csv-gradebook" className="cursor-pointer font-medium">
+                  Course gradebook
+                </Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  One row per student with their overall grade and totals
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start space-x-3 p-3 rounded-lg border border-border/40 hover:bg-muted/30 transition-colors">
+              <RadioGroupItem value="quiz" id="csv-quiz" className="mt-0.5" />
+              <div className="flex-1">
+                <Label htmlFor="csv-quiz" className="cursor-pointer font-medium">
+                  Quiz-by-quiz breakdown
+                </Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  One row per student per quiz with scores and attempts
+                </p>
+              </div>
+            </div>
+          </RadioGroup>
+
+          <DialogFooter>
+            <NeuralButton
+              variant="outline"
+              size="sm"
+              onClick={() => setCsvDialogOpen(false)}
+              disabled={loading}
+            >
+              Cancel
+            </NeuralButton>
+            <NeuralButton
+              variant="neural"
+              size="sm"
+              onClick={() => download('csv', csvSheet)}
+              disabled={loading}
+            >
+              {loading ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-1" />
+              ) : (
+                <Download className="h-4 w-4 mr-1" />
+              )}
+              Download
+            </NeuralButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/components/ui/media-upload.tsx
+++ b/src/components/ui/media-upload.tsx
@@ -51,11 +51,12 @@ export function MediaUpload({
 
     setIsUploading(true);
 
-    for (const file of acceptedFiles.slice(0, maxFiles)) {
-      const fileId = `${Date.now()}_${file.name}`;
+    // Upload a single file through the full signed-URL flow.
+    // Extracted so the batched Promise.all below stays readable.
+    const uploadOne = async (file: File) => {
+      const fileId = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}_${file.name}`;
 
       try {
-        // Initialize progress
         setUploadProgress(prev => ({ ...prev, [fileId]: 0 }));
 
         // Step 1: Get signed upload URL from server
@@ -81,10 +82,9 @@ export function MediaUpload({
         // Step 2: Upload directly to Supabase Storage
         setUploadProgress(prev => ({ ...prev, [fileId]: 20 }));
 
-        // Create XMLHttpRequest for progress tracking
         const xhr = new XMLHttpRequest();
 
-        const uploadPromise = new Promise<void>((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
           xhr.upload.addEventListener('progress', (e) => {
             if (e.lengthComputable) {
               const percentComplete = 20 + (e.loaded / e.total) * 60; // 20-80%
@@ -108,8 +108,6 @@ export function MediaUpload({
           xhr.send(file);
         });
 
-        await uploadPromise;
-
         // Step 3: Confirm upload and save metadata
         setUploadProgress(prev => ({ ...prev, [fileId]: 85 }));
 
@@ -132,14 +130,11 @@ export function MediaUpload({
 
         const result = await confirmResponse.json();
 
-        // Complete progress
         setUploadProgress(prev => ({ ...prev, [fileId]: 100 }));
 
-        // Add to uploaded files
         const newFile: MediaFile = result.media;
         setUploadedFiles(prev => [...prev, newFile]);
 
-        // Notify parent component
         if (onFileSelect) {
           onFileSelect(newFile);
         }
@@ -154,18 +149,27 @@ export function MediaUpload({
             return updated;
           });
         }, 2000);
-
       } catch (error) {
         console.error('Upload error:', error);
         toast.error(`Failed to upload ${file.name}: ${error instanceof Error ? error.message : 'Unknown error'}`);
 
-        // Clean up failed upload progress
         setUploadProgress(prev => {
           const updated = { ...prev };
           delete updated[fileId];
           return updated;
         });
       }
+    };
+
+    // Process uploads in parallel batches to avoid overwhelming the browser
+    // connection pool and Supabase. Batch size of 4 gives ~4x speedup over
+    // sequential uploads while staying well under typical HTTP/1.1 connection
+    // limits (6 per origin). Failures within a batch don't block other files.
+    const CONCURRENCY = 4;
+    const filesToUpload = acceptedFiles.slice(0, maxFiles);
+    for (let i = 0; i < filesToUpload.length; i += CONCURRENCY) {
+      const batch = filesToUpload.slice(i, i + CONCURRENCY);
+      await Promise.all(batch.map(uploadOne));
     }
 
     setIsUploading(false);


### PR DESCRIPTION
Bundles three related faculty-workflow improvements. The three features sit naturally together because course groups are the downstream consumer of the new unified gradebook export, and the bulk media speedup is a small independent win that shipped on the same branch.

## 1. Unified gradebook export (XLSX + CSV)

Faculty previously only got a quiz-by-quiz CSV. The new endpoint produces a real Excel workbook with two sheets — **Course Gradebook** (one row per student with an overall grade computed as \`sum(best points_earned) / sum(points_possible)\`) and **Quiz Breakdown** (the old 12-column view). CSV export now asks which of the two sheets to download. Header rows are bold and frozen; filename includes course slug and date.

- \`src/app/api/faculty/courses/[id]/quiz-export/route.ts\` — rewrite, adds \`format=xlsx|csv\` and \`sheet=quiz|gradebook\` query params
- \`src/components/quiz/QuizExportButton.tsx\` — dropdown to pick format, radio dialog to pick CSV sheet
- Adds \`exceljs\` dependency

## 2. Course groups + Canvas mapping

The platform is open — anyone can enroll in any course — but when a professor syncs grades to Canvas they only want to push grades for students actually in their Canvas section. This adds **course groups**: within a course, faculty create a group, add enrolled students (by picker or pasted email list), and every group has an optional \`canvas_course_id\` for the upcoming Canvas sync.

Groups also drive filtered views:
- The analytics dashboard now has a group picker that scopes all stats cards, charts, module performance, recent activity, and enrollment trend to the selected group's members (not just the export — that was misleading).
- Gradebook export picks up the same group filter and suffixes the filename with the group slug.

One group per course per student is enforced at the API layer so Canvas mapping stays 1:1.

- New migration \`20260409080439_add_course_groups\` (two tables: \`course_groups\`, \`course_group_memberships\`)
- 4 new API routes under \`/api/faculty/courses/[id]/groups/*\`
- \`src/app/faculty/courses/[id]/groups/page.tsx\` + \`src/components/faculty/CourseGroupsManager.tsx\` — list/create/edit/delete groups, add members via picker or pasted emails, bulk-add report with 6 status buckets
- \`src/app/api/faculty/analytics/[courseId]/route.ts\` — accepts \`groupId\`, validates it belongs to the course, filters all four analytics queries
- \`src/components/faculty/analytics/CourseAnalyticsDashboard.tsx\` — hoists the group picker so a single control drives both analytics and export
- \`src/components/quiz/QuizExportButton.tsx\` — now a controlled component, takes \`groupId\` as a prop

This is Phase 1 of the [Canvas LMS integration plan](docs/CANVAS_LMS_INTEGRATION_GUIDE.md) — Phase 2 will call the Canvas REST API using the \`canvas_course_id\` on each group.

## 3. Bulk media upload parallelization

Faculty uploading many files to a module were hitting a sequential loop that uploaded one file at a time. This swaps the serial loop for 4-way concurrency, cutting wall-clock time roughly 4× for typical uploads.

- \`src/components/ui/media-upload.tsx\` — batched \`Promise.all\` with a concurrency window of 4

## Commits

1. \`d02ece4\` Add unified gradebook export with XLSX and CSV formats
2. \`4e03855\` Clarify quiz export dropdown descriptions
3. \`22b0167\` Parallelize bulk media upload with 4-way concurrency
4. \`b26cedd\` Add course groups for scoped gradebook export and Canvas mapping
5. \`3c2cfb9\` Replace Radix Tabs with underline tab pattern in AddMembersDialog
6. \`ddd1d56\` Filter course analytics dashboard by group

## Test plan

Verified end-to-end on https://bcs-web2.vercel.app:

- [x] XLSX export opens in Excel with both sheets; gradebook totals hand-checked against a student
- [x] CSV + quiz sheet matches the previous export (regression check)
- [x] CSV + gradebook sheet opens cleanly
- [x] Create/rename/delete group; name-collision returns 409
- [x] Bulk add: added, already in group, already in another group, not enrolled, not found, invalid email — all 6 status buckets reported correctly
- [x] One-group-per-course enforcement: adding a student who's in another group returns 409 with conflict message
- [x] Analytics picker switches stats cards, module chart, module table, recent completions, and average progress to the selected group
- [x] Analytics picker restores full-course view on "All enrolled students"
- [x] Export filename includes group slug when filtered; no slug for "All"
- [x] Network trail confirms single \`groupId\` param flows to both \`/api/faculty/analytics/*\` and \`/api/faculty/courses/*/quiz-export\`
- [x] Bulk media upload of 8 files completes in ~1/4 the previous time
- [x] \`npx tsc --noEmit\` + \`npx next lint\` clean on all changed files