### PR TITLE
Add gradebook export, course groups, bulk media, YouTube embeds, and guide updates

### DIFF
--- a/docs/QUIZ_SYSTEM_GUIDE.md
+++ b/docs/QUIZ_SYSTEM_GUIDE.md
@@ -148,6 +148,8 @@ A **mastery check** is a low-stakes, formative assessment designed for practice 
 
 **Student experience**: Questions are presented one at a time. After answering each question, the student clicks "Check Answer" to see immediate feedback — whether they were correct, the right answer, and explanations for every option. They then proceed to the next question. After all questions, the quiz is submitted and scored.
 
+**Server-side validation**: Answer correctness is validated on the server, not in the browser. The client never receives the correct answer key before submission — it only learns the result after the server checks each answer. This prevents students from inspecting network responses to find correct answers.
+
 **When to use**: Use mastery checks for study and practice. Students can retake them unlimited times to improve their understanding. The threshold determines what counts as "mastered."
 
 ### Module Assessment
@@ -457,16 +459,17 @@ Faculty can export a module's entire question bank to JSON and import it into an
 3. Select your JSON file
 4. The system validates the format, creates all questions with options, and recreates sets with the correct memberships
 
-### CSV Grade Export
+### Gradebook Export
 
-Faculty can export quiz grades for an entire course as a CSV file. Navigate to the course analytics or use the export button. The CSV includes:
+Faculty can export quiz grades from the course analytics dashboard using the **Export Grades** button. Two formats are available:
 
-- Student name, email, and ID
-- Module title, quiz type, quiz title
-- Best score, points earned/possible, attempts used
-- Pass status and last attempt date
+**Excel (.xlsx)** — A workbook with two sheets:
+1. **Course Gradebook** — One row per student with overall grade (weighted by points: `sum(best points earned) / sum(points possible)`), totals, modules completed, and last activity
+2. **Quiz Breakdown** — One row per student per quiz with best score, points earned/possible, attempts used, pass status, and last attempt date
 
-One row is generated per student per quiz, including students with no attempts (shown as "N/A").
+**CSV** — Choose one sheet to download (CSV files can only contain a single sheet).
+
+If a **course group** is selected in the analytics picker, the export is scoped to that group's members. See the [User Guide](/guide) section on Course Groups and Gradebook Export for details.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -311,6 +311,8 @@ Faculty members see a **Clone** button on module cards. Clicking it opens a dial
 - Choose whether to clone media associations and collaborators
 - The clone starts as a private draft in your library
 
+Cloning also copies the module's **entire question bank** — all questions, answer options, explanations, question sets, and set memberships. Any quizzes (mastery checks and assessments) configured on the original module are cloned as well, including their blocks and settings. This means you can clone a fully quizzed module and immediately have a working copy without re-creating the quiz setup from scratch.
+
 ---
 
 ## 7. Interactive Playgrounds

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -18,7 +18,7 @@ Welcome to the **Brain & Cognitive Sciences (BCS) E-Learning Platform** — an i
 10. [Program Map](#10-program-map)
 11. [User Profiles](#11-user-profiles)
 12. [Student Features](#12-student-features) — Enrollment, Quizzes & Assessments, Progress, Achievements
-13. [Faculty Features](#13-faculty-features) — Courses, Modules, Question Banks, Quiz Builder, Analytics
+13. [Faculty Features](#13-faculty-features) — Courses, Modules, Content Editor, YouTube Embeds, Bulk Media, Quizzes, Analytics, Course Groups, Gradebook Export
 14. [Admin Features](#14-admin-features)
 15. [Quick Reference](#15-quick-reference)
 
@@ -699,7 +699,34 @@ These are guidelines, not rules. The key is internal consistency within a course
 
 #### Editing a Module
 
-Navigate to `/faculty/modules/edit/[id]` to update any module field, add media, or change the hierarchy.
+Navigate to `/faculty/modules/edit/[id]` to update any module field, add media, or change the hierarchy. The editor has three tabs: **Edit** (content), **Settings** (metadata, difficulty, unlock conditions), and **Quiz** (question bank and assessments).
+
+#### Module Content Editor
+
+The rich text editor supports:
+
+- **Text formatting** — Bold, italic, strikethrough, inline code
+- **Headings** — H1, H2, H3
+- **Lists** — Bullet and numbered
+- **Block quotes**
+- **Text alignment** — Left, center, right
+- **Links** — Click the link icon and enter a URL
+- **Images** — Click the upload icon to upload from your computer or enter an image URL. Images are stored in Supabase and served from your media library.
+- **YouTube videos** — Click the video icon (next to the upload icon) and paste a YouTube link. Supports `youtube.com/watch?v=...`, `youtu.be/...`, and `youtube.com/shorts/...` URLs. You can also **paste a YouTube URL directly** into the editor text — it auto-converts to an embedded video. Videos render at 16:9 aspect ratio and are responsive on mobile. Privacy mode is on by default (uses `youtube-nocookie.com`).
+- **Markdown import** — Click the import icon to upload a `.md` file, which replaces the editor content
+- **Undo / Redo** — Standard keyboard shortcuts (`Ctrl+Z` / `Ctrl+Y`)
+- **Auto-save** — Content is automatically saved after 2 seconds of inactivity
+
+#### Bulk Media Upload
+
+The **Media** panel (right sidebar of the module editor) supports uploading multiple files at once:
+
+1. Click **Media** to expand the panel
+2. Drag and drop multiple files or click to browse
+3. Files upload in parallel — each shows its own progress indicator
+4. Uploaded files appear in the module's media library and can be inserted into content
+
+Supported file types include images (PNG, JPG, GIF, WebP, SVG) and documents. This is useful for uploading a full lecture's worth of figures and diagrams in one go.
 
 ### Managing Quizzes
 
@@ -747,7 +774,66 @@ On the **Settings** tab, set the **Unlock Condition** to require students to com
 
 ### Course Analytics
 
-Faculty can view student engagement metrics for their courses, including enrollment counts and completion rates.
+Navigate to the analytics dashboard for any course you own to see student engagement at a glance. The dashboard shows:
+
+- **Statistics cards** — Total Enrollments, Active Students (last 7 days), Completion Rate, and Average Progress
+- **Module Completion Rates chart** — Bar chart of completion percentages across your top modules
+- **Enrollment Trend chart** — Line chart of new enrollments over the last 30 days
+- **Module Performance table** — Per-module breakdown with Started, Completed, Completion Rate, and Dropoff Rate columns
+- **Recent Completions** — The latest 10 module completions with timestamps
+
+#### Filtering by Group
+
+If you have created course groups (see below), a **group picker** appears in the dashboard header. Selecting a group filters **all** dashboard data — cards, charts, table, and recent activity — to show only the students in that group. The "Export Grades" button respects the same filter.
+
+### Course Groups
+
+Course groups let you scope your analytics and grade exports to a specific set of students. This is particularly useful when your platform enrollment is open but you only want to track or export grades for the students in your actual class section.
+
+#### Creating a Group
+
+1. From the course analytics page, click **Groups** in the top-right corner (or navigate to `/faculty/courses/[id]/groups`)
+2. Click **Create Group**
+3. Enter a **name** (e.g., "Spring 2026 Section A"), optional **description**, and optional **Canvas Course ID** (for future grade sync — this field has no effect today but will be used when Canvas integration is enabled)
+4. Click **Create**
+
+#### Adding Members
+
+1. Open a group and click **Add Members**
+2. Search for enrolled students by name or email, or paste a list of emails
+3. Only students who are actively enrolled in the course can be added
+4. Each student can belong to **at most one group** per course. If you try to add a student who is already in another group, you'll see an error with the conflicting group name
+
+#### Managing Groups
+
+- **Rename or update** a group by clicking its edit button
+- **Remove members** individually from the group detail view
+- **Delete a group** — this removes the group and all its memberships (students are not unenrolled from the course)
+
+### Gradebook Export
+
+The **Export Grades** button on the analytics dashboard lets you download student grades in two formats:
+
+#### Excel (.xlsx)
+
+Downloads a workbook with **two sheets**:
+
+1. **Course Gradebook** — One row per student with columns: Student Name, Student Email, Student ID, Overall Grade %, Total Points Earned, Total Points Possible, Quizzes Attempted, Quizzes Passed, Modules Completed, Modules Total, Last Activity
+2. **Quiz Breakdown** — One row per student per quiz with columns: Student Name, Student Email, Student ID, Module Title, Quiz Type, Quiz Title, Best Score %, Points Earned, Points Possible, Attempts Used, Passed, Last Attempt Date
+
+#### CSV
+
+CSV files can only contain one sheet, so you choose which one to download:
+- **Course Gradebook** — Same columns as the Excel gradebook sheet
+- **Quiz Breakdown** — Same columns as the Excel quiz sheet
+
+#### Grade Calculation
+
+The overall grade is calculated as: `sum(best points earned across all quizzes) / sum(total points possible) * 100`, rounded to one decimal place. Students with zero quiz attempts show 0%.
+
+#### Group Filtering
+
+If you select a group from the picker before clicking Export, the download only includes students in that group. The filename also includes the group name for easy identification.
 
 ### Creating Playgrounds
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -93,8 +93,8 @@ const nextConfig: NextConfig = {
             "font-src 'self' https://fonts.gstatic.com",
             // Connect sources: includes Sandpack bundler, esm.sh, and npm registry for dependency resolution
             "connect-src 'self' https://www.google-analytics.com https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com https://va.vercel-scripts.com https://*.codesandbox.io https://esm.sh https://registry.npmjs.org https://esm.run https://*.supabase.co",
-            // Frame sources: Sandpack preview iframe
-            "frame-src 'self' https://*.codesandbox.io",
+            // Frame sources: Sandpack preview iframe + YouTube embeds
+            "frame-src 'self' https://*.codesandbox.io https://www.youtube-nocookie.com https://www.youtube.com",
             "media-src 'self' blob:",
             "worker-src 'self' blob:",
             "object-src 'none'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@tiptap/extension-image": "^3.3.0",
         "@tiptap/extension-link": "^3.3.0",
         "@tiptap/extension-text-align": "^3.3.0",
+        "@tiptap/extension-youtube": "^3.3.0",
         "@tiptap/pm": "^3.3.0",
         "@tiptap/react": "^3.3.0",
         "@tiptap/starter-kit": "^3.3.0",
@@ -4191,6 +4192,19 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.3.0.tgz",
       "integrity": "sha512-ipiXsXBxmIQGqcMOaXsnP7iQ6/VO/UIxP3X3rS4ToHgVVF5RIFSs732fv5p3R88TdlVz4hqM9S39W+JesFB2Fw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.3.0"
+      }
+    },
+    "node_modules/@tiptap/extension-youtube": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-youtube/-/extension-youtube-3.3.0.tgz",
+      "integrity": "sha512-Z66fb3IOABAE4Etm637gbBZY0Ia2nI+IsmM6IIds6eJIrMTFmnRk6oFn6p594hKFNmOqxk/A3IJULAZI9vEZBw==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@tiptap/extension-image": "^3.3.0",
     "@tiptap/extension-link": "^3.3.0",
     "@tiptap/extension-text-align": "^3.3.0",
+    "@tiptap/extension-youtube": "^3.3.0",
     "@tiptap/pm": "^3.3.0",
     "@tiptap/react": "^3.3.0",
     "@tiptap/starter-kit": "^3.3.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -840,6 +840,34 @@ Inspired by official UI brand colors: Illini Orange and Illini Blue
   border: 2px solid hsl(var(--neural-primary) / 0.2);
 }
 
+/* YouTube embeds — responsive 16:9, matches image styling */
+.neural-content .neural-youtube-embed,
+.neural-content iframe[src*="youtube.com"],
+.neural-content iframe[src*="youtube-nocookie.com"] {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  margin: 2rem 0;
+}
+
+/* Tiptap wraps the iframe in a div with data-youtube-video — make it block level */
+.neural-content div[data-youtube-video] {
+  margin: 2rem 0;
+}
+.neural-content div[data-youtube-video] > iframe {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
 /* Course Map Custom Scrollbar */
 .custom-scrollbar::-webkit-scrollbar {
   width: 8px;

--- a/src/components/editor/neural-rich-text-editor.tsx
+++ b/src/components/editor/neural-rich-text-editor.tsx
@@ -6,6 +6,7 @@ import Heading from '@tiptap/extension-heading'
 import ResizableImageExtension from 'tiptap-extension-resize-image'
 import Link from '@tiptap/extension-link'
 import TextAlign from '@tiptap/extension-text-align'
+import Youtube from '@tiptap/extension-youtube'
 import { marked } from 'marked'
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { NeuralButton } from '@/components/ui/neural-button'
@@ -26,6 +27,7 @@ import {
   Code,
   Link as LinkIcon,
   Image as ImageIcon,
+  Video,
   AlignLeft,
   AlignCenter,
   AlignRight,
@@ -78,6 +80,9 @@ export function NeuralRichTextEditor({
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null)
   const [showMediaUpload, setShowMediaUpload] = useState(false)
   const [showImportConfirm, setShowImportConfirm] = useState(false)
+  const [showYoutubeDialog, setShowYoutubeDialog] = useState(false)
+  const [youtubeUrl, setYoutubeUrl] = useState('')
+  const [youtubeError, setYoutubeError] = useState<string | null>(null)
   const autoSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -116,6 +121,16 @@ export function NeuralRichTextEditor({
       }),
       TextAlign.configure({
         types: ['heading', 'paragraph'],
+      }),
+      Youtube.configure({
+        nocookie: true,
+        controls: true,
+        modestBranding: true,
+        width: 640,
+        height: 360,
+        HTMLAttributes: {
+          class: 'neural-youtube-embed',
+        },
       }),
     ],
     content,
@@ -218,6 +233,30 @@ export function NeuralRichTextEditor({
       editor.chain().focus().setLink({ href: url }).run()
     }
   }, [editor])
+
+  const openYoutubeDialog = useCallback(() => {
+    setYoutubeUrl('')
+    setYoutubeError(null)
+    setShowYoutubeDialog(true)
+  }, [])
+
+  const handleYoutubeInsert = useCallback(() => {
+    if (!editor) return
+    const trimmed = youtubeUrl.trim()
+    if (!trimmed) {
+      setYoutubeError('Please enter a YouTube URL')
+      return
+    }
+    // setYoutubeVideo returns false if the URL doesn't match a known YouTube pattern
+    const ok = editor.chain().focus().setYoutubeVideo({ src: trimmed }).run()
+    if (ok) {
+      setShowYoutubeDialog(false)
+      setYoutubeUrl('')
+      setYoutubeError(null)
+    } else {
+      setYoutubeError('That does not look like a valid YouTube URL')
+    }
+  }, [editor, youtubeUrl])
 
   const handleImportMarkdown = useCallback(() => {
     if (!editor) return
@@ -433,6 +472,15 @@ export function NeuralRichTextEditor({
             <NeuralButton
               variant="ghost"
               size="sm"
+              onClick={openYoutubeDialog}
+              title="Embed YouTube video"
+              aria-label="Embed YouTube video"
+            >
+              <Video className="h-4 w-4" />
+            </NeuralButton>
+            <NeuralButton
+              variant="ghost"
+              size="sm"
               onClick={handleImportMarkdown}
               title="Import Markdown"
               aria-label="Import markdown file"
@@ -560,6 +608,64 @@ export function NeuralRichTextEditor({
               }}
             >
               Replace Content
+            </NeuralButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* YouTube Embed Dialog */}
+      <Dialog
+        open={showYoutubeDialog}
+        onOpenChange={(open) => {
+          setShowYoutubeDialog(open)
+          if (!open) {
+            setYoutubeUrl('')
+            setYoutubeError(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Embed YouTube Video</DialogTitle>
+            <DialogDescription>
+              Paste a YouTube link (watch, share, embed, or shorts URL). The video will appear inline at 16:9.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <input
+              type="url"
+              value={youtubeUrl}
+              onChange={(e) => {
+                setYoutubeUrl(e.target.value)
+                if (youtubeError) setYoutubeError(null)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  handleYoutubeInsert()
+                }
+              }}
+              placeholder="https://www.youtube.com/watch?v=..."
+              className="w-full px-3 py-2 border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+              autoFocus
+            />
+            {youtubeError && (
+              <p className="text-sm text-destructive">{youtubeError}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <NeuralButton
+              variant="ghost"
+              onClick={() => {
+                setShowYoutubeDialog(false)
+                setYoutubeUrl('')
+                setYoutubeError(null)
+              }}
+            >
+              Cancel
+            </NeuralButton>
+            <NeuralButton variant="neural" onClick={handleYoutubeInsert}>
+              Embed
             </NeuralButton>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary

- **Unified Gradebook Export** — Faculty can export grades as XLSX (two sheets: course gradebook + quiz breakdown) or CSV (pick one sheet). Grade formula: weighted by points across all course quizzes. Export button with format picker and sheet selector dialog.
- **Course Groups** — Faculty can create groups within a course, add enrolled students as members (one group per course per student), and use groups to filter both analytics and grade exports. Includes Canvas Course ID field for future grade sync.
- **Analytics Group Filtering** — The course analytics dashboard filters all stats, charts, and tables when a group is selected. Export respects the same filter.
- **Bulk Media Upload** — Media upload now supports multiple files with 4-way parallel concurrency and per-file progress indicators.
- **YouTube Video Embeds** — Module content editor gains a YouTube embed button + paste detection via @tiptap/extension-youtube. Responsive 16:9 rendering, privacy mode (youtube-nocookie.com). CSP updated to allow YouTube iframes.
- **User Guide Updates** — New sections for content editor features, YouTube embeds, bulk media, course groups, gradebook export, and module clone quiz copying. Quiz system guide updated with server-side validation note and new export docs.

## Changes (20 files, ~3,400 lines added)

**New features:**
- `src/app/api/faculty/courses/[id]/groups/` — Full CRUD API for course groups + members
- `src/components/faculty/CourseGroupsManager.tsx` — Groups management UI
- `src/app/api/faculty/courses/[id]/quiz-export/route.ts` — Rewritten for XLSX + CSV + group filter
- `src/components/quiz/QuizExportButton.tsx` — Format picker dropdown + CSV sheet dialog
- `src/components/editor/neural-rich-text-editor.tsx` — YouTube extension + toolbar + dialog
- `prisma/schema.prisma` + migration — `course_groups` and `course_group_memberships` models

**Enhancements:**
- `src/components/faculty/analytics/CourseAnalyticsDashboard.tsx` — Group picker + filtered analytics
- `src/components/ui/media-upload.tsx` — Parallel upload with concurrency control
- `next.config.ts` — YouTube added to CSP frame-src
- `src/app/globals.css` — Responsive YouTube iframe styling

**Documentation:**
- `docs/USER_GUIDE.md` — 6 new subsections under Faculty Features
- `docs/QUIZ_SYSTEM_GUIDE.md` — Server-side validation, updated export docs

## Test plan

- [ ] XLSX export downloads with both sheets, grade formula correct
- [ ] CSV export for both gradebook and quiz sheets
- [ ] Create/rename/delete course groups
- [ ] Add/remove group members, one-group-per-course enforcement (409)
- [ ] Group picker filters all analytics dashboard data
- [ ] Export with group filter scopes to group members
- [ ] YouTube embed via toolbar button and paste detection
- [ ] YouTube renders on student side (all 3 render locations)
- [ ] Bulk media upload with multiple files in parallel
- [ ] Module clone copies question bank + quizzes
- [ ] /guide page shows new TOC entries and sections