### PR TITLE
Add Canvas LMS grade sync and env example updates

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -21,6 +21,12 @@
 #
 DATABASE_URL="postgresql://postgres.YOUR_DEV_PROJECT_ID:YOUR_DEV_PASSWORD@aws-1-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
 
+# Direct connection for Prisma migrations (session pooler, port 5432)
+# Migrations require DDL support which the transaction pooler (6543) doesn't provide
+# Format: postgresql://postgres.<PROJECT_ID>:<PASSWORD>@<HOST>:5432/postgres
+#
+DIRECT_URL="postgresql://postgres.YOUR_DEV_PROJECT_ID:YOUR_DEV_PASSWORD@aws-1-us-east-1.pooler.supabase.com:5432/postgres"
+
 # ==================== AUTHENTICATION ====================
 # NextAuth Configuration for Development
 #
@@ -47,6 +53,29 @@ EMAIL_FROM_NAME="BCS E-Learning (DEV)"
 # Node environment setting
 #
 NODE_ENV="development"
+
+# ==================== SUPABASE (FILE STORAGE) ====================
+# Your Personal Supabase Project - used for media file uploads/downloads
+#
+# NEXT_PUBLIC_SUPABASE_URL: Your Supabase project URL (Settings → API → Project URL)
+# NEXT_PUBLIC_SUPABASE_ANON_KEY: Your Supabase anon/public key (Settings → API → anon public)
+#
+NEXT_PUBLIC_SUPABASE_URL="https://YOUR_DEV_PROJECT_ID.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-anon-key-here"
+
+# ==================== ACCESS CONTROL ====================
+# Controls which users get admin roles on registration
+#
+# ADMIN_EMAILS: Comma-separated list of emails that are auto-assigned the admin role
+# SUPER_ADMIN_EMAIL: The primary admin email with elevated privileges (e.g., manage other admins)
+#
+ADMIN_EMAILS="your-email@illinois.edu"
+SUPER_ADMIN_EMAIL="your-email@illinois.edu"
+
+# ==================== TELEMETRY ====================
+# Disable Next.js anonymous telemetry data collection
+#
+NEXT_TELEMETRY_DISABLED=1
 
 # ==================== CANVAS LMS INTEGRATION (OPTIONAL) ====================
 # Only needed if testing Canvas grade sync

--- a/.env.development.example
+++ b/.env.development.example
@@ -48,6 +48,18 @@ EMAIL_FROM_NAME="BCS E-Learning (DEV)"
 #
 NODE_ENV="development"
 
+# ==================== CANVAS LMS INTEGRATION (OPTIONAL) ====================
+# Only needed if testing Canvas grade sync
+#
+# CANVAS_BASE_URL: Your institution's Canvas URL
+# CANVAS_API_TOKEN: Personal access token from Canvas profile → Settings → Approved Integrations
+# CANVAS_ALLOWED_COURSE_IDS: Comma-separated list of Canvas course IDs that can receive grade syncs
+#   This is a safety guard — syncs to unlisted courses are blocked.
+#
+CANVAS_BASE_URL="https://canvas.illinois.edu"
+CANVAS_API_TOKEN="your-canvas-personal-access-token-here"
+CANVAS_ALLOWED_COURSE_IDS="68879"
+
 # ==================== FEATURE FLAGS ====================
 # Enable/disable features in development
 #

--- a/.env.production.example
+++ b/.env.production.example
@@ -21,6 +21,12 @@
 #
 DATABASE_URL="postgresql://postgres.UNIVERSITY_PROD_PROJECT_ID:UNIVERSITY_PROD_PASSWORD@aws-1-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
 
+# Direct connection for Prisma migrations (session pooler, port 5432)
+# Migrations require DDL support which the transaction pooler (6543) doesn't provide
+# Format: postgresql://postgres.<PROJECT_ID>:<PASSWORD>@<HOST>:5432/postgres
+#
+DIRECT_URL="postgresql://postgres.UNIVERSITY_PROD_PROJECT_ID:UNIVERSITY_PROD_PASSWORD@aws-1-us-east-1.pooler.supabase.com:5432/postgres"
+
 # ==================== AUTHENTICATION ====================
 # NextAuth Configuration for Production
 #
@@ -48,6 +54,31 @@ EMAIL_FROM_NAME="BCS E-Learning"
 # Node environment setting (must be production)
 #
 NODE_ENV="production"
+
+# ==================== SUPABASE (FILE STORAGE) ====================
+# University Supabase Project - used for media file uploads/downloads
+#
+# NEXT_PUBLIC_SUPABASE_URL: University Supabase project URL (Settings → API → Project URL)
+# NEXT_PUBLIC_SUPABASE_ANON_KEY: University Supabase anon/public key (Settings → API → anon public)
+# IMPORTANT: Use the university production Supabase project, not the dev project
+#
+NEXT_PUBLIC_SUPABASE_URL="https://UNIVERSITY_PROD_PROJECT_ID.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="university-prod-supabase-anon-key-here"
+
+# ==================== ACCESS CONTROL ====================
+# Controls which users get admin roles on registration
+#
+# ADMIN_EMAILS: Comma-separated list of emails that are auto-assigned the admin role
+# SUPER_ADMIN_EMAIL: The primary admin email with elevated privileges (e.g., manage other admins)
+# IMPORTANT: Use university email addresses for production
+#
+ADMIN_EMAILS="admin1@illinois.edu,admin2@illinois.edu"
+SUPER_ADMIN_EMAIL="primary-admin@illinois.edu"
+
+# ==================== TELEMETRY ====================
+# Disable Next.js anonymous telemetry data collection
+#
+NEXT_TELEMETRY_DISABLED=1
 
 # ==================== CANVAS LMS INTEGRATION (OPTIONAL) ====================
 # Only needed if using Canvas grade sync in production

--- a/.env.production.example
+++ b/.env.production.example
@@ -49,6 +49,21 @@ EMAIL_FROM_NAME="BCS E-Learning"
 #
 NODE_ENV="production"
 
+# ==================== CANVAS LMS INTEGRATION (OPTIONAL) ====================
+# Only needed if using Canvas grade sync in production
+#
+# CANVAS_BASE_URL: Your institution's Canvas URL
+# CANVAS_API_TOKEN: Personal access token from Canvas profile → Settings → Approved Integrations
+#   IMPORTANT: Use a token from a faculty account with Teacher/TA role on the target courses.
+#   The token acts with that user's permissions — it can only modify courses they have access to.
+# CANVAS_ALLOWED_COURSE_IDS: Comma-separated list of Canvas course IDs that can receive grade syncs
+#   This is a safety guard — syncs to unlisted courses are blocked.
+#   Update this each semester when new Canvas courses are created.
+#
+CANVAS_BASE_URL="https://canvas.illinois.edu"
+CANVAS_API_TOKEN="canvas-production-personal-access-token-here"
+CANVAS_ALLOWED_COURSE_IDS="68879,73000"
+
 # ==================== FEATURE FLAGS ====================
 # Enable/disable features in production
 # Only enable stable, tested features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,9 @@ The project uses manual testing on the Vercel deployment. When adding features:
 - `RESEND_API_KEY` - API key from Resend dashboard
 - `EMAIL_FROM` - Verified sender email (e.g., `noreply@yourdomain.com`)
 - `EMAIL_FROM_NAME` - Sender display name (e.g., `BCS E-Learning`)
+- `CANVAS_BASE_URL` - Canvas LMS base URL (e.g., `https://canvas.illinois.edu`) — optional, for grade sync
+- `CANVAS_API_TOKEN` - Canvas personal access token — optional, for grade sync
+- `CANVAS_ALLOWED_COURSE_IDS` - Comma-separated Canvas course IDs allowed for sync — optional safety guard
 
 **Build Process**:
 1. Vercel runs `npm run vercel:build`

--- a/docs/CANVAS_LMS_INTEGRATION_GUIDE.md
+++ b/docs/CANVAS_LMS_INTEGRATION_GUIDE.md
@@ -1,0 +1,395 @@
+# Canvas LMS Grade Sync Guide
+
+This guide walks you through syncing quiz grades from the BCS E-Learning Platform to your Canvas course. Once set up, you can push all quiz scores to Canvas with a single button click — no more downloading spreadsheets and uploading them manually.
+
+For general information about course groups and grade exports, see the [User Guide](/guide) sections on Course Groups and Gradebook Export.
+
+---
+
+## Table of Contents
+
+1. [How It Works](#1-how-it-works)
+2. [What You Need](#2-what-you-need)
+3. [Step 1: Get Your Canvas API Token](#3-step-1-get-your-canvas-api-token)
+4. [Step 2: Find Your Canvas Course ID](#4-step-2-find-your-canvas-course-id)
+5. [Step 3: Create a Course Group in BCS](#5-step-3-create-a-course-group-in-bcs)
+6. [Step 4: Add Students to the Group](#6-step-4-add-students-to-the-group)
+7. [Step 5: Sync Grades](#7-step-5-sync-grades)
+8. [Understanding the Sync Results](#8-understanding-the-sync-results)
+9. [Re-syncing Grades](#9-re-syncing-grades)
+10. [What Gets Created in Canvas](#10-what-gets-created-in-canvas)
+11. [Student Matching](#11-student-matching)
+12. [Semester Workflow](#12-semester-workflow)
+13. [Troubleshooting](#13-troubleshooting)
+14. [FAQ](#14-faq)
+15. [Security and Safety](#15-security-and-safety)
+
+---
+
+## 1. How It Works
+
+The sync pushes quiz grades from BCS to Canvas using the Canvas REST API. Here is what happens when you click "Sync to Canvas":
+
+1. BCS looks at all quizzes in the course and finds each student's **best score** on each quiz
+2. For each quiz, BCS creates a corresponding **assignment** in your Canvas course (or reuses one from a previous sync)
+3. BCS matches students between the two systems by **email address**
+4. Each student's best score is pushed to the matching Canvas assignment
+5. You see a summary showing how many quizzes and students were synced, and whether any students could not be matched
+
+The sync is **manual** — it only runs when you click the button. Nothing is sent to Canvas automatically.
+
+---
+
+## 2. What You Need
+
+Before you can sync grades, make sure you have:
+
+| Requirement | Details |
+|---|---|
+| A **Canvas API token** | A personal access token generated from your Canvas profile (see Step 1) |
+| Your **Canvas course ID** | The numeric ID from your Canvas course URL (see Step 2) |
+| **Students enrolled in both systems** | Students must be enrolled in both BCS and Canvas, using the **same email address** |
+| **Quiz attempts in BCS** | Students must have completed at least one quiz — there are no grades to sync otherwise |
+| **Admin setup complete** | Your platform administrator must have added the Canvas API token and base URL to the server environment variables |
+
+### For Administrators
+
+The following environment variables must be set on the server (e.g., in Vercel):
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `CANVAS_BASE_URL` | `https://canvas.illinois.edu` (or your institution's Canvas URL) | The base URL of your Canvas instance |
+| `CANVAS_API_TOKEN` | Your personal access token | Authenticates API requests to Canvas |
+| `CANVAS_ALLOWED_COURSE_IDS` | Comma-separated list of course IDs (e.g., `68879,73000`) | Safety guard — only these Canvas courses can receive grade syncs. Prevents accidental pushes to unrelated courses. |
+
+---
+
+## 3. Step 1: Get Your Canvas API Token
+
+A personal access token lets BCS communicate with Canvas on your behalf.
+
+1. Log in to Canvas and go to **Account** (click your profile picture in the left sidebar) then **Settings**
+2. Scroll down to the **Approved Integrations** section
+3. Click **+ New Access Token**
+4. Enter a purpose (e.g., "BCS Grade Sync") and optionally set an expiration date
+5. Click **Generate Token**
+6. **Copy the token immediately** — Canvas will not show it again after you close the dialog
+7. Give this token to your platform administrator to add as the `CANVAS_API_TOKEN` environment variable
+
+### Important Notes
+
+- Your token acts with **your permissions**. It can only modify courses where you are a Teacher or TA.
+- **Do not share your token** with anyone. It should only be stored as a secure server environment variable.
+- If your institution has disabled personal token generation, contact your Canvas administrator to request one or to have it enabled for your account.
+- If your token expires or is revoked, the sync will stop working until a new token is configured.
+
+---
+
+## 4. Step 2: Find Your Canvas Course ID
+
+Every Canvas course has a numeric ID in its URL. You need this ID to link your BCS group to the correct Canvas course.
+
+1. Open your Canvas course in a web browser
+2. Look at the URL in your address bar. It will look like: `https://canvas.illinois.edu/courses/68879`
+3. The number at the end (`68879` in this example) is your **Canvas Course ID**
+4. Write this number down — you will enter it when creating your BCS group
+
+### Tips
+
+- Each semester typically has a **different Canvas course**, even if the course content is the same. Make sure you use the course ID for the correct semester.
+- The course does **not** need to be published for the API to work, but students must have **active enrollments** (not just pending invitations) for grades to appear in the Canvas gradebook.
+
+---
+
+## 5. Step 3: Create a Course Group in BCS
+
+Course groups connect your BCS course to a specific Canvas course. Each group represents a semester or section.
+
+1. Go to your **Faculty Dashboard** and click on the course
+2. Open the **Analytics** page for the course
+3. Click the **Groups** button in the top-right corner
+4. Click **Create Group**
+5. Fill in:
+   - **Name** — Use something descriptive like "Fall 2026" or "Spring 2027 Section A"
+   - **Description** (optional) — Any notes about this group
+   - **Canvas Course ID** — Enter the numeric Canvas course ID from Step 2 (e.g., `68879`)
+6. Click **Create**
+
+### Why Groups?
+
+Since the BCS platform is open-enrollment (anyone can sign up), groups let you define which students are in your actual class. When you sync to Canvas, only the students in the selected group are included. This also means you can have the same BCS course running across multiple semesters, each linked to a different Canvas course.
+
+---
+
+## 6. Step 4: Add Students to the Group
+
+After creating the group, you need to add your students to it.
+
+1. Open the group you just created
+2. Click **Add Members**
+3. You have two options:
+   - **Pick Enrolled** — Search for students by name or email from the list of students enrolled in your BCS course
+   - **Paste Emails** — Paste a list of student email addresses (one per line or comma-separated). This is useful if you have a class roster from Canvas or your university's system.
+4. Click **Add** to confirm
+
+### Important Rules
+
+- Only students who are **already enrolled** in the BCS course can be added to a group
+- Each student can belong to **at most one group** per course. If a student is already in another group, you will see an error message telling you which group they are in.
+- Student emails in BCS must **match** their Canvas emails for the sync to work (see [Student Matching](#11-student-matching))
+
+---
+
+## 7. Step 5: Sync Grades
+
+Once your group is set up with a Canvas Course ID and has members, you are ready to sync.
+
+1. Go to the **Analytics** page for your course
+2. In the top-right corner, select your group from the **group picker dropdown** (e.g., "Fall 2026 (30)")
+3. The **Sync to Canvas** button will appear next to the "Export Grades" button
+4. Click **Sync to Canvas**
+5. A confirmation dialog will appear showing:
+   - Which group is being synced
+   - Which Canvas course will receive the grades
+6. Click **Sync Now**
+7. Wait for the sync to complete (this may take a few seconds depending on the number of quizzes and students)
+8. Review the results summary
+
+### When the Sync Button Does Not Appear
+
+The "Sync to Canvas" button is only visible when **both** of these conditions are true:
+
+- You have selected a **specific group** from the dropdown (not "All enrolled students")
+- That group has a **Canvas Course ID** configured
+
+If you don't see the button, check that your group has a Canvas Course ID set (edit the group to verify).
+
+---
+
+## 8. Understanding the Sync Results
+
+After the sync completes, a results dialog shows three numbers:
+
+| Metric | What It Means |
+|---|---|
+| **Quizzes synced** | The number of quiz assignments that were created or updated in Canvas |
+| **Students synced** | The number of students whose grades were successfully pushed |
+| **Skipped** | The number of students in your group who could not be found in Canvas (email mismatch) |
+
+### Sync Statuses
+
+| Status | Icon | Meaning |
+|---|---|---|
+| **Sync Complete** | Green checkmark | All quizzes and students synced successfully |
+| **Sync Partially Complete** | Yellow warning | Some items synced but there were errors or skipped students |
+| **Sync Failed** | Red X | Nothing could be synced — check the error messages |
+
+### Unmatched Students
+
+If any students are skipped, their email addresses are listed under "Students not found in Canvas." This means:
+- The student's email in BCS does not match any student email in the Canvas course, OR
+- The student is not enrolled as a Student in the Canvas course
+
+### Errors
+
+If any errors occurred (e.g., permission issues, Canvas API problems), they are listed in red at the bottom of the results dialog.
+
+---
+
+## 9. Re-syncing Grades
+
+You can sync as many times as you want. Each sync:
+
+- **Updates existing grades** — If a student improved their score since the last sync, the new best score replaces the old one in Canvas
+- **Reuses existing assignments** — BCS remembers which Canvas assignments it created and does not create duplicates
+- **Picks up new students** — If you added new members to the group since the last sync, their grades will be included
+- **Picks up new quizzes** — If you added new quizzes to the course since the last sync, new Canvas assignments will be created for them
+
+### When to Re-sync
+
+- After students complete additional quiz attempts
+- After adding new students to the group
+- After adding new quizzes to the course
+- Before submitting final grades at the end of the semester
+
+---
+
+## 10. What Gets Created in Canvas
+
+When you sync for the first time, BCS creates one **assignment** in Canvas for each quiz in the course. For example, if your course has a module called "Python Programming Basics" with a Mastery Check and a Module Assessment, Canvas will get:
+
+- **Python Programming Basics — Mastery Check** (with the correct point value, e.g., 4 pts)
+- **Python Programming Basics — Module Assessment** (with the correct point value, e.g., 3 pts)
+
+These assignments:
+- Have **submission type "none"** (students do not submit anything through Canvas — the grades come from BCS)
+- Are **published** immediately so they appear in the Canvas gradebook
+- Appear in the default **Assignments** group in Canvas (you can move them to a different group in Canvas if you prefer)
+
+### Grade Values
+
+Grades are pushed as **raw points** (e.g., 3 out of 4), not percentages. Canvas automatically calculates the percentage based on the points possible.
+
+The grade pushed is always the student's **best score** across all their attempts on that quiz.
+
+---
+
+## 11. Student Matching
+
+BCS matches students between the two systems using **email addresses** (case-insensitive).
+
+For a student's grade to sync successfully:
+1. The student must be enrolled in the BCS course **and** be a member of the group being synced
+2. The student must be enrolled as a **Student** in the Canvas course (not just as a TA, Designer, or Observer)
+3. The student's **email address in BCS must match** their email address (or login ID) in Canvas
+
+### Common Matching Issues
+
+| Issue | Solution |
+|---|---|
+| Student uses a different email in BCS vs Canvas | Have the student update their BCS email to match their Canvas email (typically their university email) |
+| Student shows as "skipped" | Check that their Canvas enrollment is active and their email matches |
+| Student's Canvas enrollment is "pending" | The student needs to accept their Canvas course invitation. This can happen if the Canvas course is unpublished. |
+
+---
+
+## 12. Semester Workflow
+
+Since each semester has a different Canvas course, here is the recommended workflow:
+
+### Start of Semester
+
+1. Note your new Canvas course ID for the semester
+2. In BCS, go to your course's Analytics page and click **Groups**
+3. Create a new group (e.g., "Fall 2027") with the new Canvas Course ID
+4. Add your students to the group (use the Paste Emails tab if you have a class roster)
+5. Update the `CANVAS_ALLOWED_COURSE_IDS` environment variable to include the new course ID
+
+### During the Semester
+
+- Sync grades periodically as students complete quizzes
+- Re-sync after adding new quizzes or new students
+
+### End of Semester
+
+1. Do a final sync to push all latest grades
+2. Verify grades in the Canvas gradebook
+3. The old group remains in BCS for historical reference — you do not need to delete it
+
+### Next Semester
+
+Repeat the process with a new group and new Canvas course ID. The same BCS course can have multiple groups, each linked to a different Canvas course.
+
+---
+
+## 13. Troubleshooting
+
+### "Canvas API is not configured"
+
+The `CANVAS_BASE_URL` and `CANVAS_API_TOKEN` environment variables are not set on the server. Contact your platform administrator.
+
+### "Canvas course [ID] is not in the allowed list"
+
+The Canvas course ID you are trying to sync to is not in the `CANVAS_ALLOWED_COURSE_IDS` environment variable. Contact your platform administrator to add it.
+
+### "This group has no Canvas Course ID configured"
+
+Edit the group and add the Canvas Course ID. See [Step 3](#5-step-3-create-a-course-group-in-bcs).
+
+### "Failed to fetch Canvas students"
+
+This usually means:
+- The Canvas API token has expired or been revoked — generate a new one
+- The Canvas course ID is wrong — double-check it in your Canvas course URL
+- The Canvas API is temporarily unavailable — try again in a few minutes
+
+### "user not authorized to perform that action"
+
+Your Canvas role on the target course does not have grading permissions. You need to be a **Teacher** or **TA** on the Canvas course. Designer and Observer roles cannot push grades.
+
+### "No students found" in Canvas SpeedGrader
+
+This is a Canvas UI issue. If the Canvas course is unpublished or student enrollments are pending (not yet accepted), students may not appear in SpeedGrader or the gradebook. Ensure:
+- The Canvas course is **published**, OR
+- Students have **accepted** their enrollment invitations
+
+### Students show as "skipped"
+
+The student's email in BCS does not match any student email in the Canvas course. See [Student Matching](#11-student-matching).
+
+### Grades synced but Canvas gradebook shows dashes
+
+This can happen if:
+- The student's Canvas enrollment is pending (not yet accepted)
+- The student is enrolled as a non-Student role (TA, Designer, Observer)
+- The Canvas course is unpublished and student enrollments have not been activated
+
+### No quizzes to sync
+
+Make sure:
+- Your course has quizzes configured on its modules
+- At least one student in the group has submitted a quiz attempt
+- Quiz attempts have a status of "submitted" (not "in progress")
+
+---
+
+## 14. FAQ
+
+**Q: Does syncing delete anything in Canvas?**
+
+No. The sync only **creates** assignments and **updates** grades. It never deletes assignments, removes students, or modifies anything else in your Canvas course.
+
+**Q: What if I add more quizzes later?**
+
+New quizzes will get new Canvas assignments on the next sync. Existing assignments are not affected.
+
+**Q: What if a student retakes a quiz and gets a higher score?**
+
+The next time you sync, the new best score will overwrite the old grade in Canvas.
+
+**Q: What if a student retakes a quiz and gets a lower score?**
+
+The sync always pushes the **best** score, so the Canvas grade will not decrease.
+
+**Q: Can I sync to multiple Canvas courses from the same BCS course?**
+
+Yes. Create separate groups, each with a different Canvas Course ID. Sync each group independently.
+
+**Q: Will syncing affect my other Canvas courses?**
+
+No. The sync only touches the specific Canvas course linked to the group you selected. Additionally, a safety allowlist (`CANVAS_ALLOWED_COURSE_IDS`) prevents accidental syncs to unapproved courses.
+
+**Q: How long does the sync take?**
+
+Typically a few seconds for a course with 5-10 quizzes and 30-50 students. Larger courses may take 10-20 seconds.
+
+**Q: Can students see that grades came from BCS?**
+
+Students will see the assignment names (e.g., "Python Programming Basics — Mastery Check") and their scores in the Canvas gradebook. The assignments have submission type "none," so there is no submission to view — just the grade.
+
+**Q: What happens if I run the sync twice?**
+
+Nothing bad. Existing assignments are reused, and grades are updated with the latest best scores. It is safe to sync as often as you like.
+
+---
+
+## 15. Security and Safety
+
+### Your API Token
+
+- Your personal access token acts with **your Canvas permissions**. It can read and write in any Canvas course where you are a Teacher or TA.
+- The token is stored as a server environment variable and is **never exposed** to the browser or to students.
+- If you suspect your token has been compromised, revoke it immediately in Canvas (Settings > Approved Integrations > delete the token) and generate a new one.
+
+### Course Allowlist
+
+The `CANVAS_ALLOWED_COURSE_IDS` environment variable acts as a safety net. Even if someone enters a wrong Canvas Course ID on a group, the sync will be **blocked** unless that course ID is in the allowlist. This prevents accidental grade pushes to unrelated courses (e.g., courses where you are a TA).
+
+### What the Sync Can and Cannot Do
+
+| Can Do | Cannot Do |
+|---|---|
+| Create assignments in allowed Canvas courses | Access courses not in the allowlist |
+| Push grades for matched students | Delete assignments or grades |
+| Read the student roster of the Canvas course | Modify course settings, enrollments, or content |
+| | Access any Canvas data outside the specific course being synced |

--- a/docs/DEV_PROD_WORKFLOW.md
+++ b/docs/DEV_PROD_WORKFLOW.md
@@ -171,6 +171,11 @@ EMAIL_FROM_NAME="BCS E-Learning (DEV)"
 # Environment
 NODE_ENV="development"
 
+# Canvas LMS Grade Sync (optional — only needed if testing Canvas integration)
+CANVAS_BASE_URL="https://canvas.illinois.edu"
+CANVAS_API_TOKEN="[your-canvas-personal-access-token]"
+CANVAS_ALLOWED_COURSE_IDS="68879"  # Comma-separated list of allowed Canvas course IDs
+
 # Feature Flags (Can test experimental features)
 NEXT_PUBLIC_ENABLE_RICH_TEXT_EDITOR=true
 NEXT_PUBLIC_ENABLE_GRAPH_VISUALIZATION=true
@@ -197,6 +202,11 @@ EMAIL_FROM_NAME="BCS E-Learning"
 
 # Environment
 NODE_ENV="production"
+
+# Canvas LMS Grade Sync (optional — only needed if using Canvas integration)
+CANVAS_BASE_URL="https://canvas.illinois.edu"
+CANVAS_API_TOKEN="[canvas-personal-access-token]"
+CANVAS_ALLOWED_COURSE_IDS="68879,73000"  # Comma-separated list of allowed Canvas course IDs
 
 # Feature Flags (Production-ready features only)
 NEXT_PUBLIC_ENABLE_RICH_TEXT_EDITOR=true

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -796,7 +796,7 @@ Course groups let you scope your analytics and grade exports to a specific set o
 
 1. From the course analytics page, click **Groups** in the top-right corner (or navigate to `/faculty/courses/[id]/groups`)
 2. Click **Create Group**
-3. Enter a **name** (e.g., "Spring 2026 Section A"), optional **description**, and optional **Canvas Course ID** (for future grade sync — this field has no effect today but will be used when Canvas integration is enabled)
+3. Enter a **name** (e.g., "Spring 2026 Section A"), optional **description**, and optional **Canvas Course ID** (the numeric ID from your Canvas course URL — used for [Canvas grade sync](/guide/canvas-integration))
 4. Click **Create**
 
 #### Adding Members
@@ -836,6 +836,12 @@ The overall grade is calculated as: `sum(best points earned across all quizzes) 
 #### Group Filtering
 
 If you select a group from the picker before clicking Export, the download only includes students in that group. The filename also includes the group name for easy identification.
+
+### Canvas Grade Sync
+
+If your group has a Canvas Course ID configured, a **Sync to Canvas** button appears next to "Export Grades" when that group is selected. This pushes quiz grades directly to your Canvas gradebook — one Canvas assignment per quiz, matched by student email.
+
+For the complete setup walkthrough, see the dedicated [Canvas LMS Grade Sync Guide](/guide/canvas-integration).
 
 ### Creating Playgrounds
 

--- a/prisma/migrations/20260430134854_add_canvas_integration_tables/migration.sql
+++ b/prisma/migrations/20260430134854_add_canvas_integration_tables/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "public"."canvas_assignment_mappings" (
+    "id" TEXT NOT NULL,
+    "course_id" TEXT NOT NULL,
+    "quiz_id" TEXT NOT NULL,
+    "canvas_course_id" TEXT NOT NULL,
+    "canvas_assignment_id" INTEGER NOT NULL,
+    "canvas_assignment_name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "canvas_assignment_mappings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."canvas_sync_logs" (
+    "id" TEXT NOT NULL,
+    "course_id" TEXT NOT NULL,
+    "group_id" TEXT NOT NULL,
+    "canvas_course_id" TEXT NOT NULL,
+    "synced_by" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "quizzes_synced" INTEGER NOT NULL DEFAULT 0,
+    "students_synced" INTEGER NOT NULL DEFAULT 0,
+    "students_skipped" INTEGER NOT NULL DEFAULT 0,
+    "errors" TEXT,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMP(3),
+
+    CONSTRAINT "canvas_sync_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "canvas_assignment_mappings_course_id_idx" ON "public"."canvas_assignment_mappings"("course_id");
+
+-- CreateIndex
+CREATE INDEX "canvas_assignment_mappings_canvas_course_id_idx" ON "public"."canvas_assignment_mappings"("canvas_course_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "canvas_assignment_mappings_quiz_id_canvas_course_id_key" ON "public"."canvas_assignment_mappings"("quiz_id", "canvas_course_id");
+
+-- CreateIndex
+CREATE INDEX "canvas_sync_logs_course_id_idx" ON "public"."canvas_sync_logs"("course_id");
+
+-- CreateIndex
+CREATE INDEX "canvas_sync_logs_synced_by_idx" ON "public"."canvas_sync_logs"("synced_by");
+
+-- AddForeignKey
+ALTER TABLE "public"."canvas_assignment_mappings" ADD CONSTRAINT "canvas_assignment_mappings_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."canvas_sync_logs" ADD CONSTRAINT "canvas_sync_logs_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."canvas_sync_logs" ADD CONSTRAINT "canvas_sync_logs_synced_by_fkey" FOREIGN KEY ("synced_by") REFERENCES "public"."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,10 @@ model courses {
   course_tracking course_tracking[]
   course_groups   course_groups[]
 
+  // Canvas LMS integration
+  canvas_assignment_mappings canvas_assignment_mappings[]
+  canvas_sync_logs           canvas_sync_logs[]
+
   // Progress tracking (Week 4)
   module_progress module_progress[]      @relation("CourseProgress")
 
@@ -257,6 +261,9 @@ model users {
   course_group_memberships  course_group_memberships[] @relation("CourseGroupMember")
   added_group_members       course_group_memberships[] @relation("CourseGroupMemberAdder")
   created_course_groups     course_groups[]            @relation("CourseGroupCreator")
+
+  // Canvas LMS integration
+  canvas_sync_logs          canvas_sync_logs[]         @relation("CanvasSyncUser")
 
   @@index([role])
   @@index([account_status])
@@ -968,4 +975,48 @@ model course_group_memberships {
   @@unique([group_id, user_id])
   @@index([user_id])
   @@index([group_id])
+}
+
+// ==================== CANVAS LMS INTEGRATION ====================
+
+// Maps a BCS quiz to a Canvas assignment within a specific Canvas course.
+// When a quiz is synced for the first time, we create the Canvas assignment
+// and store the mapping here so subsequent syncs reuse the same assignment.
+model canvas_assignment_mappings {
+  id                     String   @id @default(cuid())
+  course_id              String
+  quiz_id                String
+  canvas_course_id       String   // Canvas numeric course ID (e.g. "68879")
+  canvas_assignment_id   Int      // Canvas-returned assignment ID
+  canvas_assignment_name String   // Snapshot of assignment name at creation
+  created_at             DateTime @default(now())
+  updated_at             DateTime @updatedAt
+
+  course courses @relation(fields: [course_id], references: [id], onDelete: Cascade)
+
+  @@unique([quiz_id, canvas_course_id])
+  @@index([course_id])
+  @@index([canvas_course_id])
+}
+
+// Audit log for each Canvas grade sync operation.
+model canvas_sync_logs {
+  id               String    @id @default(cuid())
+  course_id        String
+  group_id         String
+  canvas_course_id String
+  synced_by        String
+  status           String    // "success" | "partial" | "failed"
+  quizzes_synced   Int       @default(0)
+  students_synced  Int       @default(0)
+  students_skipped Int       @default(0)
+  errors           String?   // JSON array of error messages
+  started_at       DateTime  @default(now())
+  completed_at     DateTime?
+
+  course courses @relation(fields: [course_id], references: [id], onDelete: Cascade)
+  user   users   @relation("CanvasSyncUser", fields: [synced_by], references: [id])
+
+  @@index([course_id])
+  @@index([synced_by])
 }

--- a/src/app/api/faculty/courses/[id]/canvas-sync/route.ts
+++ b/src/app/api/faculty/courses/[id]/canvas-sync/route.ts
@@ -80,6 +80,19 @@ export async function POST(
     }
 
     const canvasCourseId = group.canvas_course_id;
+
+    // Guard: only allow syncing to explicitly approved Canvas courses
+    const allowedIds = (process.env.CANVAS_ALLOWED_COURSE_IDS || '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean);
+    if (allowedIds.length > 0 && !allowedIds.includes(canvasCourseId)) {
+      return NextResponse.json(
+        { error: `Canvas course ${canvasCourseId} is not in the allowed list. Update CANVAS_ALLOWED_COURSE_IDS to permit it.` },
+        { status: 403 }
+      );
+    }
+
     const groupMemberIds = group.memberships.map((m) => m.user_id);
 
     // -----------------------------------------------------------------------

--- a/src/app/api/faculty/courses/[id]/canvas-sync/route.ts
+++ b/src/app/api/faculty/courses/[id]/canvas-sync/route.ts
@@ -1,0 +1,338 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth/config';
+import { prisma } from '@/lib/db';
+import { withDatabaseRetry } from '@/lib/retry';
+import { hasFacultyAccess } from '@/lib/auth/utils';
+import { canEditCourseWithRetry } from '@/lib/collaboration/permissions';
+import {
+  getCanvasConfig,
+  getCourseStudents,
+  createAssignment,
+  updateSubmissionGrade,
+} from '@/lib/canvas/client';
+
+/**
+ * POST /api/faculty/courses/[id]/canvas-sync
+ *
+ * Syncs quiz grades to Canvas LMS for a specific group.
+ * Creates Canvas assignments (one per quiz) and pushes best scores.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: courseId } = await params;
+    const userId = session.user.id;
+
+    // Verify edit permissions
+    const canEdit = await canEditCourseWithRetry(userId, courseId);
+    if (!canEdit) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Validate Canvas config
+    const canvasConfig = getCanvasConfig();
+    if (!canvasConfig) {
+      return NextResponse.json(
+        { error: 'Canvas API is not configured. Set CANVAS_BASE_URL and CANVAS_API_TOKEN environment variables.' },
+        { status: 500 }
+      );
+    }
+
+    // Parse request body
+    const body = await request.json();
+    const groupId = body.groupId as string | undefined;
+    if (!groupId) {
+      return NextResponse.json(
+        { error: 'groupId is required' },
+        { status: 400 }
+      );
+    }
+
+    // Load group and verify it has a canvas_course_id
+    const group = await withDatabaseRetry(() =>
+      prisma.course_groups.findUnique({
+        where: { id: groupId },
+        select: {
+          id: true,
+          name: true,
+          course_id: true,
+          canvas_course_id: true,
+          memberships: { select: { user_id: true } },
+        },
+      })
+    );
+
+    if (!group || group.course_id !== courseId) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+    if (!group.canvas_course_id) {
+      return NextResponse.json(
+        { error: 'This group has no Canvas Course ID configured. Edit the group to set one.' },
+        { status: 400 }
+      );
+    }
+
+    const canvasCourseId = group.canvas_course_id;
+    const groupMemberIds = group.memberships.map((m) => m.user_id);
+
+    // -----------------------------------------------------------------------
+    // 1. Load quizzes + best scores for group members
+    // -----------------------------------------------------------------------
+    const data = await withDatabaseRetry(async () => {
+      const courseModules = await prisma.course_modules.findMany({
+        where: { course_id: courseId },
+        include: {
+          modules: {
+            select: {
+              id: true,
+              title: true,
+              quizzes: {
+                select: {
+                  id: true,
+                  title: true,
+                  attempts: {
+                    where: {
+                      status: 'submitted',
+                      user_id: { in: groupMemberIds },
+                    },
+                    include: {
+                      user: {
+                        select: { id: true, name: true, email: true },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: { sort_order: 'asc' },
+      });
+
+      return courseModules;
+    });
+
+    // Build per-quiz best scores: quiz → { pointsPossible, bestByUser }
+    type QuizSync = {
+      quizId: string;
+      quizTitle: string;
+      moduleTitle: string;
+      pointsPossible: number;
+      bestByUser: Map<string, { points: number; email: string; name: string }>;
+    };
+
+    const quizzesToSync: QuizSync[] = [];
+    for (const cm of data) {
+      for (const quiz of cm.modules.quizzes) {
+        if (quiz.attempts.length === 0) continue;
+
+        let pointsPossible = 0;
+        const bestByUser = new Map<
+          string,
+          { points: number; email: string; name: string }
+        >();
+
+        for (const a of quiz.attempts) {
+          if (a.points_possible > pointsPossible) {
+            pointsPossible = a.points_possible;
+          }
+          const prev = bestByUser.get(a.user_id);
+          if (!prev || a.points_earned > prev.points) {
+            bestByUser.set(a.user_id, {
+              points: a.points_earned,
+              email: a.user.email,
+              name: a.user.name,
+            });
+          }
+        }
+
+        if (pointsPossible > 0) {
+          quizzesToSync.push({
+            quizId: quiz.id,
+            quizTitle: quiz.title,
+            moduleTitle: cm.modules.title,
+            pointsPossible,
+            bestByUser,
+          });
+        }
+      }
+    }
+
+    if (quizzesToSync.length === 0) {
+      return NextResponse.json({
+        status: 'success',
+        message: 'No quizzes with submitted attempts to sync.',
+        quizzesSynced: 0,
+        studentsSynced: 0,
+        studentsSkipped: 0,
+        unmatchedStudents: [],
+        errors: [],
+      });
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Fetch Canvas students and build email → Canvas user ID map
+    // -----------------------------------------------------------------------
+    const canvasStudentsResult = await getCourseStudents(
+      canvasConfig,
+      canvasCourseId
+    );
+
+    if (!canvasStudentsResult.ok) {
+      const canvasErr = canvasStudentsResult.error;
+      return NextResponse.json(
+        { error: `Failed to fetch Canvas students: ${canvasErr.message}` },
+        { status: 502 }
+      );
+    }
+
+    const canvasStudents = canvasStudentsResult.data;
+    const emailToCanvasId = new Map<string, number>();
+    for (const student of canvasStudents) {
+      // Match by email or login_id (case-insensitive)
+      const email = (student.email || student.login_id || '').toLowerCase();
+      if (email) {
+        emailToCanvasId.set(email, student.id);
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Load existing assignment mappings
+    // -----------------------------------------------------------------------
+    const existingMappings = await withDatabaseRetry(() =>
+      prisma.canvas_assignment_mappings.findMany({
+        where: {
+          course_id: courseId,
+          canvas_course_id: canvasCourseId,
+          quiz_id: { in: quizzesToSync.map((q) => q.quizId) },
+        },
+      })
+    );
+    const mappingByQuizId = new Map(
+      existingMappings.map((m) => [m.quiz_id, m])
+    );
+
+    // -----------------------------------------------------------------------
+    // 4. Sync each quiz
+    // -----------------------------------------------------------------------
+    let quizzesSynced = 0;
+    const syncedStudentEmails = new Set<string>();
+    const unmatchedStudents = new Set<string>();
+    const errors: string[] = [];
+
+    for (const quiz of quizzesToSync) {
+      // 4a. Get or create Canvas assignment
+      let canvasAssignmentId: number;
+      const existing = mappingByQuizId.get(quiz.quizId);
+
+      if (existing) {
+        canvasAssignmentId = existing.canvas_assignment_id;
+      } else {
+        const assignmentName = `${quiz.moduleTitle} — ${quiz.quizTitle}`;
+        const createResult = await createAssignment(
+          canvasConfig,
+          canvasCourseId,
+          { name: assignmentName, pointsPossible: quiz.pointsPossible }
+        );
+
+        if (!createResult.ok) {
+          errors.push(
+            `Failed to create assignment for "${quiz.quizTitle}": ${createResult.error.message}`
+          );
+          continue;
+        }
+
+        canvasAssignmentId = createResult.data.id;
+
+        // Store the mapping
+        await withDatabaseRetry(() =>
+          prisma.canvas_assignment_mappings.create({
+            data: {
+              course_id: courseId,
+              quiz_id: quiz.quizId,
+              canvas_course_id: canvasCourseId,
+              canvas_assignment_id: canvasAssignmentId,
+              canvas_assignment_name: assignmentName,
+            },
+          })
+        );
+      }
+
+      // 4b. Push grades for each student
+      for (const [, best] of quiz.bestByUser) {
+        const canvasUserId = emailToCanvasId.get(best.email.toLowerCase());
+        if (!canvasUserId) {
+          unmatchedStudents.add(best.email);
+          continue;
+        }
+
+        const gradeResult = await updateSubmissionGrade(
+          canvasConfig,
+          canvasCourseId,
+          canvasAssignmentId,
+          canvasUserId,
+          best.points
+        );
+
+        if (!gradeResult.ok) {
+          errors.push(
+            `Failed to push grade for ${best.email} on "${quiz.quizTitle}": ${gradeResult.error.message}`
+          );
+        } else {
+          syncedStudentEmails.add(best.email);
+        }
+      }
+
+      quizzesSynced++;
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Log the sync
+    // -----------------------------------------------------------------------
+    const status =
+      errors.length === 0
+        ? 'success'
+        : quizzesSynced > 0
+          ? 'partial'
+          : 'failed';
+
+    await withDatabaseRetry(() =>
+      prisma.canvas_sync_logs.create({
+        data: {
+          course_id: courseId,
+          group_id: groupId,
+          canvas_course_id: canvasCourseId,
+          synced_by: userId,
+          status,
+          quizzes_synced: quizzesSynced,
+          students_synced: syncedStudentEmails.size,
+          students_skipped: unmatchedStudents.size,
+          errors: errors.length > 0 ? JSON.stringify(errors) : null,
+          completed_at: new Date(),
+        },
+      })
+    );
+
+    return NextResponse.json({
+      status,
+      quizzesSynced,
+      studentsSynced: syncedStudentEmails.size,
+      studentsSkipped: unmatchedStudents.size,
+      unmatchedStudents: Array.from(unmatchedStudents),
+      errors,
+    });
+  } catch (error) {
+    console.error('Canvas sync error:', error);
+    return NextResponse.json(
+      { error: 'Failed to sync grades to Canvas' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/guide/[slug]/page.tsx
+++ b/src/app/guide/[slug]/page.tsx
@@ -14,6 +14,10 @@ const GUIDE_DOCS: Record<string, { file: string; title: string }> = {
     file: "QUIZ_SYSTEM_GUIDE.md",
     title: "Quiz System Guide",
   },
+  "canvas-integration": {
+    file: "CANVAS_LMS_INTEGRATION_GUIDE.md",
+    title: "Canvas LMS Grade Sync Guide",
+  },
 }
 
 interface PageProps {

--- a/src/components/faculty/analytics/CanvasSyncButton.tsx
+++ b/src/components/faculty/analytics/CanvasSyncButton.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useState } from 'react';
+import { NeuralButton } from '@/components/ui/neural-button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Upload, Loader2, CheckCircle2, AlertTriangle, XCircle } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface SyncResult {
+  status: 'success' | 'partial' | 'failed';
+  quizzesSynced: number;
+  studentsSynced: number;
+  studentsSkipped: number;
+  unmatchedStudents: string[];
+  errors: string[];
+  message?: string;
+}
+
+interface CanvasSyncButtonProps {
+  courseId: string;
+  groupId: string;
+  canvasCourseId?: string | null;
+  groupName?: string;
+}
+
+export function CanvasSyncButton({
+  courseId,
+  groupId,
+  canvasCourseId,
+  groupName,
+}: CanvasSyncButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [resultOpen, setResultOpen] = useState(false);
+  const [result, setResult] = useState<SyncResult | null>(null);
+
+  // Only show when a specific group with a Canvas ID is selected
+  if (!canvasCourseId || groupId === 'all') return null;
+
+  const handleSync = async () => {
+    setConfirmOpen(false);
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/faculty/courses/${courseId}/canvas-sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ groupId }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error || 'Sync failed');
+        return;
+      }
+
+      setResult(data);
+      setResultOpen(true);
+
+      if (data.status === 'success') {
+        toast.success('Grades synced to Canvas');
+      } else if (data.status === 'partial') {
+        toast.warning('Grades partially synced — some errors occurred');
+      } else {
+        toast.error('Sync failed');
+      }
+    } catch {
+      toast.error('Failed to sync grades to Canvas');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <NeuralButton
+        variant="outline"
+        size="sm"
+        disabled={loading}
+        onClick={() => setConfirmOpen(true)}
+      >
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin mr-1" />
+        ) : (
+          <Upload className="h-4 w-4 mr-1" />
+        )}
+        Sync to Canvas
+      </NeuralButton>
+
+      {/* Confirmation dialog */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Sync Grades to Canvas</DialogTitle>
+            <DialogDescription>
+              This will push quiz grades for <strong>{groupName || 'this group'}</strong> to
+              Canvas course <strong>{canvasCourseId}</strong>.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2 text-sm text-muted-foreground py-2">
+            <p>For each quiz in this course, the sync will:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Create a Canvas assignment (or reuse one from a previous sync)</li>
+              <li>Push each student&apos;s best score</li>
+              <li>Match students by email address</li>
+            </ul>
+          </div>
+
+          <DialogFooter>
+            <NeuralButton
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmOpen(false)}
+            >
+              Cancel
+            </NeuralButton>
+            <NeuralButton
+              variant="neural"
+              size="sm"
+              onClick={handleSync}
+            >
+              <Upload className="h-4 w-4 mr-1" />
+              Sync Now
+            </NeuralButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Results dialog */}
+      <Dialog open={resultOpen} onOpenChange={setResultOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {result?.status === 'success' && (
+                <CheckCircle2 className="h-5 w-5 text-green-500" />
+              )}
+              {result?.status === 'partial' && (
+                <AlertTriangle className="h-5 w-5 text-yellow-500" />
+              )}
+              {result?.status === 'failed' && (
+                <XCircle className="h-5 w-5 text-red-500" />
+              )}
+              Sync {result?.status === 'success' ? 'Complete' : result?.status === 'partial' ? 'Partially Complete' : 'Failed'}
+            </DialogTitle>
+          </DialogHeader>
+
+          {result && (
+            <div className="space-y-4 py-2">
+              {result.message ? (
+                <p className="text-sm text-muted-foreground">{result.message}</p>
+              ) : (
+                <>
+                  {/* Stats */}
+                  <div className="grid grid-cols-3 gap-3">
+                    <div className="rounded-lg border border-border/40 p-3 text-center">
+                      <div className="text-2xl font-bold">{result.quizzesSynced}</div>
+                      <div className="text-xs text-muted-foreground">Quizzes synced</div>
+                    </div>
+                    <div className="rounded-lg border border-border/40 p-3 text-center">
+                      <div className="text-2xl font-bold text-green-600">{result.studentsSynced}</div>
+                      <div className="text-xs text-muted-foreground">Students synced</div>
+                    </div>
+                    <div className="rounded-lg border border-border/40 p-3 text-center">
+                      <div className="text-2xl font-bold text-yellow-600">{result.studentsSkipped}</div>
+                      <div className="text-xs text-muted-foreground">Skipped</div>
+                    </div>
+                  </div>
+
+                  {/* Unmatched students */}
+                  {result.unmatchedStudents.length > 0 && (
+                    <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3">
+                      <div className="text-sm font-medium text-yellow-600 mb-1">
+                        Students not found in Canvas:
+                      </div>
+                      <ul className="text-xs text-muted-foreground space-y-0.5">
+                        {result.unmatchedStudents.map((email) => (
+                          <li key={email}>{email}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {/* Errors */}
+                  {result.errors.length > 0 && (
+                    <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-3">
+                      <div className="text-sm font-medium text-red-600 mb-1">
+                        Errors:
+                      </div>
+                      <ul className="text-xs text-muted-foreground space-y-0.5">
+                        {result.errors.map((err, i) => (
+                          <li key={i}>{err}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <NeuralButton
+              variant="outline"
+              size="sm"
+              onClick={() => setResultOpen(false)}
+            >
+              Close
+            </NeuralButton>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/faculty/analytics/CourseAnalyticsDashboard.tsx
+++ b/src/components/faculty/analytics/CourseAnalyticsDashboard.tsx
@@ -17,6 +17,7 @@ import {
 import { ArrowLeft, Users, TrendingUp, Award, Activity } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { QuizExportButton } from '@/components/quiz/QuizExportButton';
+import { CanvasSyncButton } from '@/components/faculty/analytics/CanvasSyncButton';
 import {
   Select,
   SelectContent,
@@ -29,6 +30,7 @@ interface Group {
   id: string;
   name: string;
   memberCount: number;
+  canvasCourseId?: string | null;
 }
 
 interface AnalyticsData {
@@ -181,6 +183,12 @@ export default function CourseAnalyticsDashboard({ courseId }: CourseAnalyticsDa
             </Select>
           )}
           <QuizExportButton courseId={courseId} groupId={selectedGroupId} />
+          <CanvasSyncButton
+            courseId={courseId}
+            groupId={selectedGroupId}
+            canvasCourseId={groups.find(g => g.id === selectedGroupId)?.canvasCourseId}
+            groupName={groups.find(g => g.id === selectedGroupId)?.name}
+          />
         </div>
       </div>
 

--- a/src/lib/canvas/client.ts
+++ b/src/lib/canvas/client.ts
@@ -1,0 +1,197 @@
+/**
+ * Canvas LMS REST API client for grade sync.
+ *
+ * Uses a personal access token stored in environment variables.
+ * All methods are server-side only (used in API routes).
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface CanvasConfig {
+  baseUrl: string; // e.g. "https://canvas.illinois.edu"
+  token: string;
+}
+
+export function getCanvasConfig(): CanvasConfig | null {
+  const baseUrl = process.env.CANVAS_BASE_URL;
+  const token = process.env.CANVAS_API_TOKEN;
+  if (!baseUrl || !token) return null;
+  return { baseUrl: baseUrl.replace(/\/+$/, ''), token };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CanvasUser {
+  id: number;
+  name: string;
+  email: string | null;
+  login_id: string | null;
+}
+
+export interface CanvasAssignment {
+  id: number;
+  name: string;
+  points_possible: number;
+  published: boolean;
+}
+
+export interface CanvasApiError {
+  status: number;
+  message: string;
+}
+
+export interface CanvasSuccess<T> {
+  ok: true;
+  data: T;
+  error?: undefined;
+}
+
+export interface CanvasFailure {
+  ok: false;
+  data?: undefined;
+  error: CanvasApiError;
+}
+
+export type CanvasResult<T> = CanvasSuccess<T> | CanvasFailure;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function canvasFetch(
+  config: CanvasConfig,
+  path: string,
+  init?: RequestInit
+): Promise<Response> {
+  const url = `${config.baseUrl}${path}`;
+  return fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  });
+}
+
+async function handleResponse<T>(res: Response): Promise<CanvasResult<T>> {
+  if (!res.ok) {
+    let message = `Canvas API ${res.status}`;
+    try {
+      const body = await res.json();
+      message = body.errors?.[0]?.message || body.message || message;
+    } catch {
+      // non-JSON error body
+    }
+    return { ok: false, error: { status: res.status, message } };
+  }
+  const data = (await res.json()) as T;
+  return { ok: true, data };
+}
+
+/**
+ * Parse the Link header to find the "next" page URL.
+ * Canvas returns: `<https://...?page=2&per_page=10>; rel="next", ...`
+ */
+function getNextPageUrl(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  const parts = linkHeader.split(',');
+  for (const part of parts) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// API methods
+// ---------------------------------------------------------------------------
+
+/**
+ * List all students enrolled in a Canvas course.
+ * Handles pagination automatically via Link headers.
+ */
+export async function getCourseStudents(
+  config: CanvasConfig,
+  canvasCourseId: string
+): Promise<CanvasResult<CanvasUser[]>> {
+  const students: CanvasUser[] = [];
+  let url: string | null =
+    `/api/v1/courses/${canvasCourseId}/users?enrollment_type[]=student&per_page=100`;
+
+  while (url) {
+    // url may be absolute (from Link header) or relative (first call)
+    const res = url.startsWith('http')
+      ? await fetch(url, {
+          headers: { Authorization: `Bearer ${config.token}` },
+        })
+      : await canvasFetch(config, url);
+
+    if (!res.ok) {
+      return handleResponse<CanvasUser[]>(res);
+    }
+
+    const page = (await res.json()) as CanvasUser[];
+    students.push(...page);
+
+    url = getNextPageUrl(res.headers.get('Link'));
+  }
+
+  return { ok: true, data: students };
+}
+
+/**
+ * Create an assignment in a Canvas course.
+ */
+export async function createAssignment(
+  config: CanvasConfig,
+  canvasCourseId: string,
+  opts: { name: string; pointsPossible: number }
+): Promise<CanvasResult<CanvasAssignment>> {
+  const res = await canvasFetch(
+    config,
+    `/api/v1/courses/${canvasCourseId}/assignments`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        assignment: {
+          name: opts.name,
+          points_possible: opts.pointsPossible,
+          submission_types: ['none'],
+          published: true,
+        },
+      }),
+    }
+  );
+  return handleResponse<CanvasAssignment>(res);
+}
+
+/**
+ * Push a grade for a single student on a single assignment.
+ * `grade` is raw points earned (e.g. 8 out of 10).
+ */
+export async function updateSubmissionGrade(
+  config: CanvasConfig,
+  canvasCourseId: string,
+  assignmentId: number,
+  canvasUserId: number,
+  grade: number
+): Promise<CanvasResult<{ grade: string }>> {
+  const res = await canvasFetch(
+    config,
+    `/api/v1/courses/${canvasCourseId}/assignments/${assignmentId}/submissions/${canvasUserId}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        submission: {
+          posted_grade: grade.toString(),
+        },
+      }),
+    }
+  );
+  return handleResponse<{ grade: string }>(res);
+}


### PR DESCRIPTION
## Summary
- Adds Canvas LMS grade sync via REST API: faculty can push module-completion grades from a course's analytics dashboard to a configured Canvas course.
- Includes a Canvas course ID allowlist (`CANVAS_ALLOWED_COURSE_IDS`) as a safety guard against accidental pushes to the wrong Canvas course.
- Documents the integration in `CLAUDE.md`, `DEV_PROD_WORKFLOW.md`, and a new user guide (`docs/CANVAS_LMS_INTEGRATION_GUIDE.md`, surfaced at `/guide`).
- Backfills missing variables in `.env.development.example` and `.env.production.example` (`DIRECT_URL`, Supabase storage keys, admin email allowlist, Next.js telemetry opt-out, and Canvas vars) so new contributors can configure environments without guessing.

## Changes
- **API**: `POST /api/faculty/courses/[id]/canvas-sync` — pulls module-completion data and pushes grades to Canvas with allowlist enforcement.
- **Canvas client**: `src/lib/canvas/client.ts` — REST wrapper for Canvas grade submission.
- **UI**: `CanvasSyncButton` added to `CourseAnalyticsDashboard` for one-click sync.
- **Schema**: New Prisma migration adds Canvas-related fields/tracking.
- **Docs**: Canvas integration guide + updates to `USER_GUIDE.md` and dev/prod workflow docs.

## Test plan
- [ ] Configure `CANVAS_BASE_URL`, `CANVAS_API_TOKEN`, and `CANVAS_ALLOWED_COURSE_IDS` in Vercel preview env
- [ ] Run Prisma migration on dev DB and verify schema applied cleanly
- [ ] As a faculty user on dev, open a course's analytics dashboard and trigger Canvas sync to a sandbox Canvas course
- [ ] Verify grades appear in Canvas for enrolled students with module progress
- [ ] Confirm sync is rejected when the target Canvas course ID is not in `CANVAS_ALLOWED_COURSE_IDS`
- [ ] Confirm the new `/guide` entry renders the Canvas LMS integration guide