### PR TITLE
Enable RLS on Canvas/Groups tables

### DIFF
--- a/prisma/migrations/20260507034520_enable_rls_canvas_groups_tables/migration.sql
+++ b/prisma/migrations/20260507034520_enable_rls_canvas_groups_tables/migration.sql
@@ -1,0 +1,9 @@
+-- Enable Row Level Security on the 4 Canvas/Groups tables added after
+-- the initial RLS migration. Same pattern: no policies are added, so
+-- PostgREST (anon/authenticated) access is fully denied. Prisma uses
+-- the postgres role which bypasses RLS.
+
+ALTER TABLE "course_groups" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "course_group_memberships" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "canvas_assignment_mappings" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "canvas_sync_logs" ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Enables Row Level Security on 4 tables that were missing it: `course_groups`, `course_group_memberships`, `canvas_assignment_mappings`, `canvas_sync_logs`
- These tables were added after the initial RLS migration and were left unprotected
- Same pattern as existing RLS: no policies added, so PostgREST (anon/authenticated) access is fully denied while Prisma (postgres role) bypasses RLS

## Test plan
- [x] Migration applied successfully on dev database
- [x] Verified all 39 tables now show `rls_enabled: true` via Supabase MCP
- [x] No Supabase critical advisory remaining
- [ ] After merge, verify prod tables show RLS enabled