### PR TITLE
Add per-faculty Canvas API tokens with encrypted storage

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -81,13 +81,15 @@ NEXT_TELEMETRY_DISABLED=1
 # Only needed if testing Canvas grade sync
 #
 # CANVAS_BASE_URL: Your institution's Canvas URL
-# CANVAS_API_TOKEN: Personal access token from Canvas profile → Settings → Approved Integrations
-# CANVAS_ALLOWED_COURSE_IDS: Comma-separated list of Canvas course IDs that can receive grade syncs
-#   This is a safety guard — syncs to unlisted courses are blocked.
+# CANVAS_TOKEN_ENCRYPTION_KEY: Encrypts per-faculty Canvas tokens stored in the database
+#   Generate with: openssl rand -hex 32
+#   WARNING: If rotated, all faculty must re-enter their Canvas tokens
+#
+# NOTE: Faculty manage their own Canvas API tokens via Profile Settings.
+#   Canvas Course IDs are verified against Canvas API when entering them on a group.
 #
 CANVAS_BASE_URL="https://canvas.illinois.edu"
-CANVAS_API_TOKEN="your-canvas-personal-access-token-here"
-CANVAS_ALLOWED_COURSE_IDS="68879"
+CANVAS_TOKEN_ENCRYPTION_KEY="generate-with-openssl-rand-hex-32"
 
 # ==================== ERROR TRACKING (SENTRY) ====================
 # Optional: Set up a Sentry project at https://sentry.io for error tracking

--- a/.env.production.example
+++ b/.env.production.example
@@ -84,16 +84,15 @@ NEXT_TELEMETRY_DISABLED=1
 # Only needed if using Canvas grade sync in production
 #
 # CANVAS_BASE_URL: Your institution's Canvas URL
-# CANVAS_API_TOKEN: Personal access token from Canvas profile → Settings → Approved Integrations
-#   IMPORTANT: Use a token from a faculty account with Teacher/TA role on the target courses.
-#   The token acts with that user's permissions — it can only modify courses they have access to.
-# CANVAS_ALLOWED_COURSE_IDS: Comma-separated list of Canvas course IDs that can receive grade syncs
-#   This is a safety guard — syncs to unlisted courses are blocked.
-#   Update this each semester when new Canvas courses are created.
+# CANVAS_TOKEN_ENCRYPTION_KEY: Encrypts per-faculty Canvas tokens stored in the database
+#   Generate with: openssl rand -hex 32
+#   WARNING: If rotated, all faculty must re-enter their Canvas tokens
+#
+# NOTE: Faculty manage their own Canvas API tokens via Profile Settings.
+#   Canvas Course IDs are verified against Canvas API when entering them on a group.
 #
 CANVAS_BASE_URL="https://canvas.illinois.edu"
-CANVAS_API_TOKEN="canvas-production-personal-access-token-here"
-CANVAS_ALLOWED_COURSE_IDS="68879,73000"
+CANVAS_TOKEN_ENCRYPTION_KEY="generate-with-openssl-rand-hex-32"
 
 # ==================== ERROR TRACKING (SENTRY) ====================
 # Sentry project for production error tracking and performance monitoring

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,8 +435,7 @@ The project uses manual testing on the Vercel deployment. When adding features:
 - `EMAIL_FROM` - Verified sender email (e.g., `noreply@yourdomain.com`)
 - `EMAIL_FROM_NAME` - Sender display name (e.g., `BCS E-Learning`)
 - `CANVAS_BASE_URL` - Canvas LMS base URL (e.g., `https://canvas.illinois.edu`) — optional, for grade sync
-- `CANVAS_API_TOKEN` - Canvas personal access token — optional, for grade sync
-- `CANVAS_ALLOWED_COURSE_IDS` - Comma-separated Canvas course IDs allowed for sync — optional safety guard
+- `CANVAS_TOKEN_ENCRYPTION_KEY` - 32-byte hex key for encrypting per-faculty Canvas tokens (generate with `openssl rand -hex 32`)
 
 **Build Process**:
 1. Vercel runs `npm run vercel:build`

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -6,7 +6,7 @@ This guide covers all administrative features on the BCS E-Learning Platform —
 
 | Role | Description |
 |------|-------------|
-| **Admin** | Full platform management: user administration, faculty approvals, content moderation, audit logs |
+| **Admin** | Full platform management: user administration, faculty approvals, content moderation, audit logs. Admins also have all faculty capabilities (course/module creation, grade sync, Canvas integration). |
 | **Super Admin** | All admin capabilities plus the ability to manage other admin accounts (promote, modify, or delete admins). Only one super admin exists per platform. |
 
 ---

--- a/docs/CANVAS_LMS_INTEGRATION_GUIDE.md
+++ b/docs/CANVAS_LMS_INTEGRATION_GUIDE.md
@@ -53,7 +53,7 @@ Before you can sync grades, make sure you have:
 | Your **Canvas course ID** | The numeric ID from your Canvas course URL (see Step 2) |
 | **Students enrolled in both systems** | Students must be enrolled in both BCS and Canvas, using the **same email address** |
 | **Quiz attempts in BCS** | Students must have completed at least one quiz — there are no grades to sync otherwise |
-| **Admin setup complete** | Your platform administrator must have added the Canvas API token and base URL to the server environment variables |
+| **Server configuration** | Your platform administrator must have set `CANVAS_BASE_URL` and `CANVAS_TOKEN_ENCRYPTION_KEY` in the server environment variables |
 
 ### For Administrators
 
@@ -84,7 +84,7 @@ A personal access token lets BCS communicate with Canvas on your behalf. Each fa
 - Your token acts with **your permissions**. It can only modify courses where you are a Teacher or TA.
 - Your token is **encrypted at rest** in the database using AES-256-GCM. It is never displayed after saving.
 - **Do not share your token** with anyone.
-- If your institution has disabled personal token generation, contact your Canvas administrator to request one or to have it enabled for your account.
+- If your institution has disabled personal token generation, see [this guide](https://answers.uillinois.edu/illinois/internal/150325) to request access, or contact your Canvas administrator.
 - If your token expires or is revoked, the sync will stop working until you update it in your profile settings.
 
 ---
@@ -297,7 +297,7 @@ If you do not have a Canvas API token configured, or prefer to upload grades man
 | No Canvas API token is configured on the server | API token is configured and working |
 | You want to review grades before they appear in Canvas | You want one-click grade pushing |
 | Your institution restricts API token generation | API access is available |
-| You need to import grades into a Canvas course not in the allowlist | The Canvas course is in the allowlist |
+| You only need a one-time export | You want ongoing, repeatable syncs |
 
 ### How to Export a Canvas CSV
 

--- a/docs/CANVAS_LMS_INTEGRATION_GUIDE.md
+++ b/docs/CANVAS_LMS_INTEGRATION_GUIDE.md
@@ -62,14 +62,13 @@ The following environment variables must be set on the server (e.g., in Vercel):
 | Variable | Value | Purpose |
 |---|---|---|
 | `CANVAS_BASE_URL` | `https://canvas.illinois.edu` (or your institution's Canvas URL) | The base URL of your Canvas instance |
-| `CANVAS_API_TOKEN` | Your personal access token | Authenticates API requests to Canvas |
-| `CANVAS_ALLOWED_COURSE_IDS` | Comma-separated list of course IDs (e.g., `68879,73000`) | Safety guard — only these Canvas courses can receive grade syncs. Prevents accidental pushes to unrelated courses. |
+| `CANVAS_TOKEN_ENCRYPTION_KEY` | 32-byte hex key (generate with `openssl rand -hex 32`) | Encrypts per-faculty Canvas tokens stored in the database. **If rotated, all faculty must re-enter their tokens.** |
 
 ---
 
 ## 3. Step 1: Get Your Canvas API Token
 
-A personal access token lets BCS communicate with Canvas on your behalf.
+A personal access token lets BCS communicate with Canvas on your behalf. Each faculty member manages their own token.
 
 1. Log in to Canvas and go to **Account** (click your profile picture in the left sidebar) then **Settings**
 2. Scroll down to the **Approved Integrations** section
@@ -77,14 +76,16 @@ A personal access token lets BCS communicate with Canvas on your behalf.
 4. Enter a purpose (e.g., "BCS Grade Sync") and optionally set an expiration date
 5. Click **Generate Token**
 6. **Copy the token immediately** — Canvas will not show it again after you close the dialog
-7. Give this token to your platform administrator to add as the `CANVAS_API_TOKEN` environment variable
+7. Go to your **BCS Profile Settings** (Faculty Profile > Edit) and paste your token in the **Canvas LMS Integration** section
+8. Click **Save Token** — the platform will validate it against Canvas before saving
 
 ### Important Notes
 
 - Your token acts with **your permissions**. It can only modify courses where you are a Teacher or TA.
-- **Do not share your token** with anyone. It should only be stored as a secure server environment variable.
+- Your token is **encrypted at rest** in the database using AES-256-GCM. It is never displayed after saving.
+- **Do not share your token** with anyone.
 - If your institution has disabled personal token generation, contact your Canvas administrator to request one or to have it enabled for your account.
-- If your token expires or is revoked, the sync will stop working until a new token is configured.
+- If your token expires or is revoked, the sync will stop working until you update it in your profile settings.
 
 ---
 
@@ -264,9 +265,9 @@ Since each semester has a different Canvas course, here is the recommended workf
 
 1. Note your new Canvas course ID for the semester
 2. In BCS, go to your course's Analytics page and click **Groups**
-3. Create a new group (e.g., "Fall 2027") with the new Canvas Course ID
-4. Add your students to the group (use the Paste Emails tab if you have a class roster)
-5. Update the `CANVAS_ALLOWED_COURSE_IDS` environment variable to include the new course ID
+3. Create a new group (e.g., "Fall 2027") and enter the new Canvas Course ID
+4. Click **Verify** to confirm it's the correct Canvas course before saving
+5. Add your students to the group (use the Paste Emails tab if you have a class roster)
 
 ### During the Semester
 
@@ -367,11 +368,7 @@ And when opened in Excel or Google Sheets:
 
 ### "Canvas API is not configured"
 
-The `CANVAS_BASE_URL` and `CANVAS_API_TOKEN` environment variables are not set on the server. Contact your platform administrator.
-
-### "Canvas course [ID] is not in the allowed list"
-
-The Canvas course ID you are trying to sync to is not in the `CANVAS_ALLOWED_COURSE_IDS` environment variable. Contact your platform administrator to add it.
+Either `CANVAS_BASE_URL` is not set on the server, or you haven't added your Canvas API token. Go to your Faculty Profile > Edit and add your token in the Canvas LMS Integration section.
 
 ### "This group has no Canvas Course ID configured"
 
@@ -438,7 +435,7 @@ Yes. Create separate groups, each with a different Canvas Course ID. Sync each g
 
 **Q: Will syncing affect my other Canvas courses?**
 
-No. The sync only touches the specific Canvas course linked to the group you selected. Additionally, a safety allowlist (`CANVAS_ALLOWED_COURSE_IDS`) prevents accidental syncs to unapproved courses.
+No. The sync only touches the specific Canvas course linked to the group you selected. Each faculty member uses their own Canvas API token, which only has access to their own courses. Additionally, Canvas Course IDs are verified against Canvas when you enter them on a group.
 
 **Q: How long does the sync take?**
 
@@ -464,13 +461,13 @@ Nothing bad. Existing assignments are reused, and grades are updated with the la
 
 ### Course Allowlist
 
-The `CANVAS_ALLOWED_COURSE_IDS` environment variable acts as a safety net. Even if someone enters a wrong Canvas Course ID on a group, the sync will be **blocked** unless that course ID is in the allowlist. This prevents accidental grade pushes to unrelated courses (e.g., courses where you are a TA).
+Each faculty member uses their own Canvas API token, which is scoped to courses where they have Teacher/TA access. When entering a Canvas Course ID on a group, the system verifies it against Canvas and shows the course name for confirmation — preventing typos or accidental links to wrong courses. The sync confirmation dialog also displays the Canvas course name so you can double-check before pushing grades.
 
 ### What the Sync Can and Cannot Do
 
 | Can Do | Cannot Do |
 |---|---|
-| Create assignments in allowed Canvas courses | Access courses not in the allowlist |
+| Create assignments in Canvas courses you have access to | Access courses where you are not a Teacher/TA |
 | Push grades for matched students | Delete assignments or grades |
 | Read the student roster of the Canvas course | Modify course settings, enrollments, or content |
 | | Access any Canvas data outside the specific course being synced |

--- a/docs/DEV_PROD_WORKFLOW.md
+++ b/docs/DEV_PROD_WORKFLOW.md
@@ -186,8 +186,7 @@ SENTRY_AUTH_TOKEN=""                             # Auth token for source map upl
 
 # ── Canvas LMS Grade Sync (optional) ──
 CANVAS_BASE_URL="https://canvas.illinois.edu"
-CANVAS_API_TOKEN="[your-canvas-personal-access-token]"
-CANVAS_ALLOWED_COURSE_IDS="68879"               # Comma-separated safety guard
+CANVAS_TOKEN_ENCRYPTION_KEY="[openssl rand -hex 32]" # Encrypts per-faculty Canvas tokens
 
 # ── Telemetry ──
 NEXT_TELEMETRY_DISABLED=1
@@ -234,8 +233,7 @@ SENTRY_AUTH_TOKEN="sntrys_[your-auth-token]"    # Sensitive — has write access
 
 # ── Canvas LMS Grade Sync (optional) ──
 CANVAS_BASE_URL="https://canvas.illinois.edu"
-CANVAS_API_TOKEN="[canvas-personal-access-token]"
-CANVAS_ALLOWED_COURSE_IDS="68879,73000"         # Update each semester
+CANVAS_TOKEN_ENCRYPTION_KEY="[openssl rand -hex 32]" # Encrypts per-faculty Canvas tokens
 
 # ── Telemetry ──
 NEXT_TELEMETRY_DISABLED=1
@@ -267,8 +265,7 @@ NEXT_PUBLIC_ENABLE_ANALYTICS=true                # Enable analytics in prod
 | `SENTRY_PROJECT` | Sentry project slug | No |
 | `SENTRY_AUTH_TOKEN` | Sentry auth token for source map uploads | Yes |
 | `CANVAS_BASE_URL` | Canvas LMS instance URL | No |
-| `CANVAS_API_TOKEN` | Canvas personal access token | Yes |
-| `CANVAS_ALLOWED_COURSE_IDS` | Safety guard for Canvas sync targets | No |
+| `CANVAS_TOKEN_ENCRYPTION_KEY` | Encrypts per-faculty Canvas tokens in DB | Yes |
 | `NEXT_TELEMETRY_DISABLED` | Disable Next.js telemetry | No |
 
 **Important Notes:**

--- a/docs/DEV_PROD_WORKFLOW.md
+++ b/docs/DEV_PROD_WORKFLOW.md
@@ -186,7 +186,7 @@ SENTRY_AUTH_TOKEN=""                             # Auth token for source map upl
 
 # ── Canvas LMS Grade Sync (optional) ──
 CANVAS_BASE_URL="https://canvas.illinois.edu"
-CANVAS_TOKEN_ENCRYPTION_KEY="[openssl rand -hex 32]" # Encrypts per-faculty Canvas tokens
+CANVAS_TOKEN_ENCRYPTION_KEY="<see generation steps below>"  # Encrypts per-faculty Canvas tokens
 
 # ── Telemetry ──
 NEXT_TELEMETRY_DISABLED=1
@@ -196,6 +196,23 @@ NEXT_PUBLIC_ENABLE_RICH_TEXT_EDITOR=true
 NEXT_PUBLIC_ENABLE_GRAPH_VISUALIZATION=true
 NEXT_PUBLIC_ENABLE_ANALYTICS=false               # Disable analytics in dev
 ```
+
+#### Generating `CANVAS_TOKEN_ENCRYPTION_KEY`
+
+This key encrypts faculty Canvas API tokens at rest in the database. Generate it once per environment (dev and prod should use **different** keys):
+
+```bash
+# Run in any terminal (macOS, Linux, or WSL):
+openssl rand -hex 32
+```
+
+This outputs a 64-character hex string (e.g., `a1b2c3d4...`). Copy the full string and set it as the value of `CANVAS_TOKEN_ENCRYPTION_KEY` in Vercel.
+
+**Important:**
+- Mark this variable as **Sensitive** in Vercel — you will not need to view it again after setting it.
+- Use a **different key** for dev and prod environments.
+- **Do not rotate this key** unless necessary. If rotated, all faculty must re-enter their Canvas tokens because previously encrypted tokens cannot be decrypted with a new key.
+- If you do not plan to use Canvas grade sync, you can skip this variable entirely.
 
 ### Production Variables (University Vercel)
 
@@ -233,7 +250,7 @@ SENTRY_AUTH_TOKEN="sntrys_[your-auth-token]"    # Sensitive — has write access
 
 # ── Canvas LMS Grade Sync (optional) ──
 CANVAS_BASE_URL="https://canvas.illinois.edu"
-CANVAS_TOKEN_ENCRYPTION_KEY="[openssl rand -hex 32]" # Encrypts per-faculty Canvas tokens
+CANVAS_TOKEN_ENCRYPTION_KEY="<see generation steps above>" # Encrypts per-faculty Canvas tokens
 
 # ── Telemetry ──
 NEXT_TELEMETRY_DISABLED=1
@@ -243,6 +260,8 @@ NEXT_PUBLIC_ENABLE_RICH_TEXT_EDITOR=true
 NEXT_PUBLIC_ENABLE_GRAPH_VISUALIZATION=true
 NEXT_PUBLIC_ENABLE_ANALYTICS=true                # Enable analytics in prod
 ```
+
+> **Note:** Generate `CANVAS_TOKEN_ENCRYPTION_KEY` with `openssl rand -hex 32` — see the [generation steps](#generating-canvas_token_encryption_key) in the Development Variables section above. Use a **different** key for production than development.
 
 ### Variable Reference
 

--- a/docs/FACULTY_GUIDE.md
+++ b/docs/FACULTY_GUIDE.md
@@ -306,9 +306,44 @@ If you select a group from the picker before clicking Export, the download only 
 
 ## 10. Canvas Grade Sync
 
-If your group has a Canvas Course ID configured, a **Sync to Canvas** button appears next to "Export Grades" when that group is selected. This pushes quiz grades directly to your Canvas gradebook — one Canvas assignment per quiz, matched by student email.
+The platform can push quiz grades directly to your Canvas gradebook — one Canvas assignment per quiz, matched by student email. Setup takes about five minutes.
 
-For the complete setup walkthrough, see the dedicated [Canvas LMS Grade Sync Guide](/guide/canvas-integration).
+For the full reference (CSV alternative, troubleshooting, FAQ), see the dedicated [Canvas LMS Grade Sync Guide](/guide/canvas-integration).
+
+### 10.1 Add Your Canvas API Token
+
+Each faculty member manages their own Canvas token. Your token is encrypted at rest and is never displayed after saving.
+
+1. In **Canvas**, go to **Account** > **Settings** > **Approved Integrations** > **+ New Access Token**
+2. Enter a purpose (e.g., "BCS Grade Sync"), optionally set an expiry, and click **Generate Token**
+3. **Copy the token immediately** — Canvas will not show it again
+4. In BCS, go to your **Profile** > **Edit Profile** (or navigate to `/faculty/profile/edit` or `/admin/profile/edit`)
+5. Scroll down to the **Canvas LMS Integration** section
+6. Paste your token and click **Save Token**
+7. The platform validates the token against Canvas before saving — if it is invalid or expired, you will see an error
+
+To update or remove your token later, return to the same section on your profile edit page.
+
+> **Can't generate a token?** Some Canvas accounts have token generation disabled. If you don't see the **+ New Access Token** option, follow the instructions at [https://answers.uillinois.edu/illinois/internal/150325](https://answers.uillinois.edu/illinois/internal/150325) to request access.
+
+### 10.2 Create a Group with a Canvas Course ID
+
+1. On your course's **Analytics** page, click **Groups**
+2. Click **Create Group** and fill in a name (e.g., "Fall 2026")
+3. Enter the numeric **Canvas Course ID** (found in your Canvas course URL, e.g., `https://canvas.illinois.edu/courses/68879` → `68879`)
+4. Click **Verify** — the platform fetches the course name from Canvas so you can confirm it is the right course
+5. Once verified, click **Create**
+6. Add students to the group (Pick Enrolled or Paste Emails)
+
+### 10.3 Sync Grades
+
+1. On the **Analytics** page, select your group from the dropdown
+2. The **Sync to Canvas** button appears next to "Export Grades"
+3. Click **Sync to Canvas** — a confirmation dialog shows the group name and the Canvas course name
+4. Click **Sync Now**
+5. Review the results: quizzes synced, students synced, and any skipped students (email mismatch)
+
+You can re-sync at any time. Existing Canvas assignments are reused, and grades are updated with the latest best scores.
 
 ---
 
@@ -814,4 +849,10 @@ Faculty can create and edit learning paths from `/faculty/paths`. The Learning P
 
 ## 16. Editing Faculty Profile
 
-Navigate to your profile edit page at `/faculty/profile/edit` to update your bio, speciality, university, interested fields, avatar, and social links.
+Navigate to your profile edit page at `/faculty/profile/edit` (or `/admin/profile/edit` for admins) to update your information:
+
+- **Basic Info** — Name, About, Speciality, University
+- **Interested Fields** — Add/remove topic tags
+- **Avatar URL** — Link to your profile image
+- **Academic & Social Links** — Google Scholar, Personal Website, LinkedIn, Twitter/X, GitHub
+- **Canvas LMS Integration** — Add, update, or remove your Canvas API token for grade sync (see [Canvas Grade Sync](#10-canvas-grade-sync))

--- a/prisma/migrations/20260511170409_add_per_faculty_canvas_token/migration.sql
+++ b/prisma/migrations/20260511170409_add_per_faculty_canvas_token/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."users" ADD COLUMN     "canvas_api_token_encrypted" TEXT,
+ADD COLUMN     "canvas_token_updated_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -265,6 +265,10 @@ model users {
   // Canvas LMS integration
   canvas_sync_logs          canvas_sync_logs[]         @relation("CanvasSyncUser")
 
+  // Per-faculty Canvas API token (encrypted at rest)
+  canvas_api_token_encrypted  String?
+  canvas_token_updated_at     DateTime?
+
   @@index([role])
   @@index([account_status])
   @@index([email])

--- a/src/app/admin/profile/edit/page.tsx
+++ b/src/app/admin/profile/edit/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Header } from '@/components/Header'
+import { CanvasTokenSettings } from '@/components/faculty/CanvasTokenSettings'
 
 export default function AdminEditProfilePage() {
   const { data: session, status } = useSession()
@@ -336,6 +337,9 @@ export default function AdminEditProfilePage() {
                 />
               </div>
             </div>
+
+            {/* Canvas Integration */}
+            <CanvasTokenSettings />
 
             {/* Actions */}
             <div className="flex gap-4 pt-4">

--- a/src/app/api/faculty/canvas-course/validate/route.ts
+++ b/src/app/api/faculty/canvas-course/validate/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth/config'
+import { hasFacultyAccess } from '@/lib/auth/utils'
+import { getCanvasConfigForUser, getCanvasCourse } from '@/lib/canvas/client'
+
+// GET /api/faculty/canvas-course/validate?courseId=68879
+// Validates a Canvas Course ID using the faculty's own token and returns the course name.
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth()
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const canvasCourseId = request.nextUrl.searchParams.get('courseId')
+    if (!canvasCourseId || !/^\d+$/.test(canvasCourseId)) {
+      return NextResponse.json(
+        { error: 'A valid numeric Canvas Course ID is required.' },
+        { status: 400 }
+      )
+    }
+
+    const config = await getCanvasConfigForUser(session.user.id)
+    if (!config) {
+      return NextResponse.json(
+        { error: 'Canvas is not configured. Please add your Canvas API token in your profile settings.' },
+        { status: 400 }
+      )
+    }
+
+    const result = await getCanvasCourse(config, canvasCourseId)
+
+    if (!result.ok) {
+      if (result.error.status === 404 || result.error.status === 401 || result.error.status === 403) {
+        return NextResponse.json(
+          { error: `Canvas course ${canvasCourseId} was not found, or you don't have access to it.` },
+          { status: 404 }
+        )
+      }
+      return NextResponse.json(
+        { error: `Canvas API error: ${result.error.message}` },
+        { status: 502 }
+      )
+    }
+
+    return NextResponse.json({
+      id: result.data.id,
+      name: result.data.name,
+      courseCode: result.data.course_code,
+    })
+  } catch (error) {
+    console.error('Error validating Canvas course:', error)
+    return NextResponse.json({ error: 'Failed to validate Canvas course' }, { status: 500 })
+  }
+}

--- a/src/app/api/faculty/canvas-token/route.ts
+++ b/src/app/api/faculty/canvas-token/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth/config'
+import { prisma } from '@/lib/db'
+import { withDatabaseRetry } from '@/lib/retry'
+import { hasFacultyAccess } from '@/lib/auth/utils'
+import { encrypt } from '@/lib/canvas/encryption'
+import { validateCanvasToken } from '@/lib/canvas/client'
+import { z } from 'zod'
+
+const tokenSchema = z.object({
+  token: z.string().min(1, 'Token is required').max(500),
+})
+
+// PUT /api/faculty/canvas-token — Save or update Canvas API token
+export async function PUT(request: NextRequest) {
+  try {
+    const session = await auth()
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const parsed = tokenSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.errors.map(e => e.message) },
+        { status: 400 }
+      )
+    }
+
+    const { token } = parsed.data
+
+    // Validate the token against Canvas API before saving
+    const baseUrl = process.env.CANVAS_BASE_URL
+    if (!baseUrl) {
+      return NextResponse.json(
+        { error: 'Canvas is not configured on this platform. Contact an administrator.' },
+        { status: 500 }
+      )
+    }
+
+    const validation = await validateCanvasToken({
+      baseUrl: baseUrl.replace(/\/+$/, ''),
+      token,
+    })
+
+    if (!validation.ok) {
+      if (validation.error.status === 401) {
+        return NextResponse.json(
+          { error: 'Invalid Canvas API token. Please check that your token is correct and not expired.' },
+          { status: 400 }
+        )
+      }
+      // Non-auth Canvas errors — don't block the save (Canvas might be temporarily down)
+      console.warn('Canvas token validation returned non-auth error:', validation.error)
+    }
+
+    // Encrypt and store
+    const encrypted = encrypt(token)
+    const now = new Date()
+
+    await withDatabaseRetry(() =>
+      prisma.users.update({
+        where: { id: session.user.id },
+        data: {
+          canvas_api_token_encrypted: encrypted,
+          canvas_token_updated_at: now,
+        },
+      })
+    )
+
+    return NextResponse.json({ success: true, updatedAt: now.toISOString() })
+  } catch (error) {
+    console.error('Error saving Canvas token:', error)
+    const message = error instanceof Error && error.message.includes('CANVAS_TOKEN_ENCRYPTION_KEY')
+      ? 'Canvas token encryption is not configured. Contact an administrator.'
+      : 'Failed to save Canvas token'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+// DELETE /api/faculty/canvas-token — Remove Canvas API token
+export async function DELETE() {
+  try {
+    const session = await auth()
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    await withDatabaseRetry(() =>
+      prisma.users.update({
+        where: { id: session.user.id },
+        data: {
+          canvas_api_token_encrypted: null,
+          canvas_token_updated_at: null,
+        },
+      })
+    )
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error removing Canvas token:', error)
+    return NextResponse.json({ error: 'Failed to remove Canvas token' }, { status: 500 })
+  }
+}

--- a/src/app/api/faculty/canvas-token/status/route.ts
+++ b/src/app/api/faculty/canvas-token/status/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth/config'
+import { prisma } from '@/lib/db'
+import { withDatabaseRetry } from '@/lib/retry'
+import { hasFacultyAccess } from '@/lib/auth/utils'
+
+// GET /api/faculty/canvas-token/status — Check if token is configured (never returns the token)
+export async function GET() {
+  try {
+    const session = await auth()
+    if (!session?.user?.id || !hasFacultyAccess(session)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await withDatabaseRetry(() =>
+      prisma.users.findUnique({
+        where: { id: session.user.id },
+        select: {
+          canvas_api_token_encrypted: true,
+          canvas_token_updated_at: true,
+        },
+      })
+    )
+
+    return NextResponse.json({
+      configured: !!user?.canvas_api_token_encrypted,
+      updatedAt: user?.canvas_token_updated_at?.toISOString() ?? null,
+    })
+  } catch (error) {
+    console.error('Error checking Canvas token status:', error)
+    return NextResponse.json({ error: 'Failed to check token status' }, { status: 500 })
+  }
+}

--- a/src/app/api/faculty/courses/[id]/canvas-sync/route.ts
+++ b/src/app/api/faculty/courses/[id]/canvas-sync/route.ts
@@ -5,7 +5,7 @@ import { withDatabaseRetry } from '@/lib/retry';
 import { hasFacultyAccess } from '@/lib/auth/utils';
 import { canEditCourseWithRetry } from '@/lib/collaboration/permissions';
 import {
-  getCanvasConfig,
+  getCanvasConfigForUser,
   getCourseStudents,
   createAssignment,
   updateSubmissionGrade,
@@ -36,12 +36,12 @@ export async function POST(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    // Validate Canvas config
-    const canvasConfig = getCanvasConfig();
+    // Validate Canvas config (uses per-faculty encrypted token)
+    const canvasConfig = await getCanvasConfigForUser(userId);
     if (!canvasConfig) {
       return NextResponse.json(
-        { error: 'Canvas API is not configured. Set CANVAS_BASE_URL and CANVAS_API_TOKEN environment variables.' },
-        { status: 500 }
+        { error: 'Canvas API is not configured. Please add your Canvas API token in your profile settings.' },
+        { status: 400 }
       );
     }
 
@@ -80,18 +80,6 @@ export async function POST(
     }
 
     const canvasCourseId = group.canvas_course_id;
-
-    // Guard: only allow syncing to explicitly approved Canvas courses
-    const allowedIds = (process.env.CANVAS_ALLOWED_COURSE_IDS || '')
-      .split(',')
-      .map((id) => id.trim())
-      .filter(Boolean);
-    if (allowedIds.length > 0 && !allowedIds.includes(canvasCourseId)) {
-      return NextResponse.json(
-        { error: `Canvas course ${canvasCourseId} is not in the allowed list. Update CANVAS_ALLOWED_COURSE_IDS to permit it.` },
-        { status: 403 }
-      );
-    }
 
     const groupMemberIds = group.memberships.map((m) => m.user_id);
 

--- a/src/app/faculty/profile/edit/page.tsx
+++ b/src/app/faculty/profile/edit/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Header } from '@/components/Header'
+import { CanvasTokenSettings } from '@/components/faculty/CanvasTokenSettings'
 
 export default function FacultyEditProfilePage() {
   const { data: session, status } = useSession()
@@ -336,6 +337,9 @@ export default function FacultyEditProfilePage() {
                 />
               </div>
             </div>
+
+            {/* Canvas Integration */}
+            <CanvasTokenSettings />
 
             {/* Actions */}
             <div className="flex gap-4 pt-4">

--- a/src/components/faculty/CanvasTokenSettings.tsx
+++ b/src/components/faculty/CanvasTokenSettings.tsx
@@ -1,0 +1,259 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Key, CheckCircle2, AlertCircle, Trash2, Loader2, ExternalLink, Eye, EyeOff } from 'lucide-react'
+
+interface TokenStatus {
+  configured: boolean
+  updatedAt: string | null
+}
+
+export function CanvasTokenSettings() {
+  const [status, setStatus] = useState<TokenStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [showInput, setShowInput] = useState(false)
+  const [showToken, setShowToken] = useState(false)
+  const [token, setToken] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
+  useEffect(() => {
+    fetchStatus()
+  }, [])
+
+  const fetchStatus = async () => {
+    try {
+      const res = await fetch('/api/faculty/canvas-token/status')
+      if (res.ok) {
+        const data = await res.json()
+        setStatus(data)
+      }
+    } catch {
+      // Silently fail — component will show unconfigured state
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!token.trim()) {
+      setError('Please enter your Canvas API token.')
+      return
+    }
+
+    setSaving(true)
+    setError('')
+    setSuccess('')
+
+    try {
+      const res = await fetch('/api/faculty/canvas-token', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: token.trim() }),
+      })
+
+      const data = await res.json()
+
+      if (res.ok && data.success) {
+        setSuccess('Canvas API token saved successfully.')
+        setToken('')
+        setShowInput(false)
+        setShowToken(false)
+        setStatus({ configured: true, updatedAt: data.updatedAt })
+      } else {
+        setError(data.error || 'Failed to save token.')
+      }
+    } catch {
+      setError('An error occurred. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    setError('')
+    setSuccess('')
+
+    try {
+      const res = await fetch('/api/faculty/canvas-token', { method: 'DELETE' })
+      const data = await res.json()
+
+      if (res.ok && data.success) {
+        setSuccess('Canvas API token removed.')
+        setStatus({ configured: false, updatedAt: null })
+        setShowDeleteConfirm(false)
+      } else {
+        setError(data.error || 'Failed to remove token.')
+      }
+    } catch {
+      setError('An error occurred. Please try again.')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="pt-4 border-t border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+          <Key className="h-5 w-5" />
+          Canvas LMS Integration
+        </h2>
+        <div className="flex items-center gap-2 text-gray-500 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading...
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="pt-4 border-t border-gray-200">
+      <h2 className="text-lg font-semibold text-gray-900 mb-2 flex items-center gap-2">
+        <Key className="h-5 w-5" />
+        Canvas LMS Integration
+      </h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Connect your Canvas account to sync quiz grades. Your token is encrypted and stored securely.
+      </p>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-red-50 text-red-800 border border-red-200 flex items-start gap-2 text-sm">
+          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="mb-4 p-3 rounded-lg bg-green-50 text-green-800 border border-green-200 flex items-start gap-2 text-sm">
+          <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          {success}
+        </div>
+      )}
+
+      {status?.configured && !showInput ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm">
+            <CheckCircle2 className="h-4 w-4 text-green-600" />
+            <span className="text-green-700 font-medium">Canvas token configured</span>
+            {status.updatedAt && (
+              <span className="text-gray-400">
+                — last updated {new Date(status.updatedAt).toLocaleDateString()}
+              </span>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => { setShowInput(true); setError(''); setSuccess('') }}
+              className="px-4 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200"
+            >
+              Update Token
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowDeleteConfirm(true); setError(''); setSuccess('') }}
+              className="px-4 py-2 text-sm bg-red-50 text-red-700 rounded-lg hover:bg-red-100 flex items-center gap-1"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Remove
+            </button>
+          </div>
+
+          {showDeleteConfirm && (
+            <div className="p-3 rounded-lg bg-red-50 border border-red-200">
+              <p className="text-sm text-red-800 mb-2">
+                Are you sure? You won&apos;t be able to sync grades until you add a new token.
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:bg-gray-400"
+                >
+                  {deleting ? 'Removing...' : 'Yes, Remove'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteConfirm(false)}
+                  className="px-3 py-1.5 text-sm bg-white text-gray-700 rounded-lg border hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {!status?.configured && (
+            <div className="p-3 rounded-lg bg-blue-50 border border-blue-200 text-sm text-blue-800">
+              To sync quiz grades to Canvas, you need a personal access token.
+              Go to Canvas &rarr; Account &rarr; Settings &rarr; Approved Integrations &rarr; New Access Token.
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="canvas-token" className="block text-sm font-medium text-gray-700 mb-1">
+              Canvas API Token
+            </label>
+            <div className="relative">
+              <input
+                type={showToken ? 'text' : 'password'}
+                id="canvas-token"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="Paste your Canvas personal access token"
+                className="w-full px-3 py-2 pr-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm"
+              />
+              <button
+                type="button"
+                onClick={() => setShowToken(!showToken)}
+                className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
+              >
+                {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || !token.trim()}
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center gap-1"
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Validating & Saving...
+                </>
+              ) : (
+                'Save Token'
+              )}
+            </button>
+            {status?.configured && (
+              <button
+                type="button"
+                onClick={() => { setShowInput(false); setToken(''); setShowToken(false); setError('') }}
+                className="px-4 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+
+          <p className="text-xs text-gray-400 flex items-center gap-1">
+            <ExternalLink className="h-3 w-3" />
+            See our Canvas Integration Guide for detailed setup instructions.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/faculty/CourseGroupsManager.tsx
+++ b/src/components/faculty/CourseGroupsManager.tsx
@@ -453,17 +453,68 @@ function GroupFormDialog({
   const [canvasCourseId, setCanvasCourseId] = useState('');
   const [saving, setSaving] = useState(false);
 
+  // Canvas Course ID verification state
+  const [verifying, setVerifying] = useState(false);
+  const [verifiedCourse, setVerifiedCourse] = useState<{
+    id: number;
+    name: string;
+    courseCode: string;
+  } | null>(null);
+  const [verifyError, setVerifyError] = useState('');
+
   useEffect(() => {
     if (open) {
       setName(group?.name || '');
       setDescription(group?.description || '');
       setCanvasCourseId(group?.canvasCourseId || '');
+      setVerifiedCourse(null);
+      setVerifyError('');
     }
   }, [open, group]);
+
+  // Reset verification when Canvas Course ID changes
+  const handleCanvasCourseIdChange = (value: string) => {
+    setCanvasCourseId(value);
+    setVerifiedCourse(null);
+    setVerifyError('');
+  };
+
+  const verifyCourse = async () => {
+    const id = canvasCourseId.trim();
+    if (!id) return;
+    if (!/^\d+$/.test(id)) {
+      setVerifyError('Canvas Course ID must be a number.');
+      return;
+    }
+
+    setVerifying(true);
+    setVerifyError('');
+    setVerifiedCourse(null);
+
+    try {
+      const res = await fetch(`/api/faculty/canvas-course/validate?courseId=${id}`);
+      const data = await res.json();
+
+      if (res.ok) {
+        setVerifiedCourse(data);
+      } else {
+        setVerifyError(data.error || 'Could not verify this Canvas Course ID.');
+      }
+    } catch {
+      setVerifyError('Failed to verify. Please check your network connection.');
+    } finally {
+      setVerifying(false);
+    }
+  };
 
   const save = async () => {
     if (!name.trim()) {
       toast.error('Name is required');
+      return;
+    }
+    // Require verification if a Canvas Course ID is provided
+    if (canvasCourseId.trim() && !verifiedCourse) {
+      toast.error('Please verify the Canvas Course ID before saving.');
       return;
     }
     setSaving(true);
@@ -530,15 +581,55 @@ function GroupFormDialog({
           </div>
           <div className="space-y-1">
             <Label htmlFor="group-canvas">Canvas Course ID</Label>
-            <Input
-              id="group-canvas"
-              value={canvasCourseId}
-              onChange={(e) => setCanvasCourseId(e.target.value)}
-              placeholder="Numeric Canvas course ID (optional)"
-            />
-            <p className="text-xs text-muted-foreground">
-              Used later when syncing grades to Canvas. You can leave blank for now.
-            </p>
+            <div className="flex gap-2">
+              <Input
+                id="group-canvas"
+                value={canvasCourseId}
+                onChange={(e) => handleCanvasCourseIdChange(e.target.value)}
+                placeholder="Numeric Canvas course ID (optional)"
+                className="flex-1"
+              />
+              <NeuralButton
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={verifyCourse}
+                disabled={verifying || !canvasCourseId.trim()}
+              >
+                {verifying ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  'Verify'
+                )}
+              </NeuralButton>
+            </div>
+
+            {verifiedCourse && (
+              <div className="mt-2 p-2.5 rounded-lg border border-green-200 bg-green-50 flex items-start gap-2">
+                <CheckCircle2 className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
+                <div className="text-sm">
+                  <p className="font-medium text-green-800">
+                    {verifiedCourse.courseCode}: {verifiedCourse.name}
+                  </p>
+                  <p className="text-green-700 text-xs">
+                    Canvas Course ID {verifiedCourse.id} — grades will sync to this course.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {verifyError && (
+              <div className="mt-2 p-2.5 rounded-lg border border-red-200 bg-red-50 flex items-start gap-2">
+                <AlertCircle className="h-4 w-4 text-red-600 mt-0.5 flex-shrink-0" />
+                <p className="text-sm text-red-800">{verifyError}</p>
+              </div>
+            )}
+
+            {!verifiedCourse && !verifyError && (
+              <p className="text-xs text-muted-foreground">
+                Enter your Canvas course ID and click Verify to confirm it&apos;s the right course. You can find the ID in the Canvas course URL.
+              </p>
+            )}
           </div>
         </div>
 

--- a/src/components/faculty/analytics/CanvasSyncButton.tsx
+++ b/src/components/faculty/analytics/CanvasSyncButton.tsx
@@ -40,9 +40,30 @@ export function CanvasSyncButton({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [resultOpen, setResultOpen] = useState(false);
   const [result, setResult] = useState<SyncResult | null>(null);
+  const [canvasCourseName, setCanvasCourseName] = useState<string | null>(null);
+  const [verifyingCourse, setVerifyingCourse] = useState(false);
 
   // Only show when a specific group with a Canvas ID is selected
   if (!canvasCourseId || groupId === 'all') return null;
+
+  const openConfirmDialog = async () => {
+    setConfirmOpen(true);
+    // Fetch the Canvas course name for display in the confirmation
+    if (!canvasCourseName) {
+      setVerifyingCourse(true);
+      try {
+        const res = await fetch(`/api/faculty/canvas-course/validate?courseId=${canvasCourseId}`);
+        if (res.ok) {
+          const data = await res.json();
+          setCanvasCourseName(`${data.courseCode}: ${data.name}`);
+        }
+      } catch {
+        // Non-critical — dialog still works with just the ID
+      } finally {
+        setVerifyingCourse(false);
+      }
+    }
+  };
 
   const handleSync = async () => {
     setConfirmOpen(false);
@@ -84,7 +105,7 @@ export function CanvasSyncButton({
         variant="outline"
         size="sm"
         disabled={loading}
-        onClick={() => setConfirmOpen(true)}
+        onClick={openConfirmDialog}
       >
         {loading ? (
           <Loader2 className="h-4 w-4 animate-spin mr-1" />
@@ -100,18 +121,38 @@ export function CanvasSyncButton({
           <DialogHeader>
             <DialogTitle>Sync Grades to Canvas</DialogTitle>
             <DialogDescription>
-              This will push quiz grades for <strong>{groupName || 'this group'}</strong> to
-              Canvas course <strong>{canvasCourseId}</strong>.
+              Please confirm you want to push grades to Canvas.
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-2 text-sm text-muted-foreground py-2">
-            <p>For each quiz in this course, the sync will:</p>
-            <ul className="list-disc pl-5 space-y-1">
-              <li>Create a Canvas assignment (or reuse one from a previous sync)</li>
-              <li>Push each student&apos;s best score</li>
-              <li>Match students by email address</li>
-            </ul>
+          <div className="space-y-3 py-2">
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 space-y-1.5">
+              <div className="text-sm">
+                <span className="text-muted-foreground">Group: </span>
+                <strong>{groupName || 'this group'}</strong>
+              </div>
+              <div className="text-sm">
+                <span className="text-muted-foreground">Canvas Course: </span>
+                {verifyingCourse ? (
+                  <span className="text-muted-foreground inline-flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" /> Verifying...
+                  </span>
+                ) : canvasCourseName ? (
+                  <strong>{canvasCourseName}</strong>
+                ) : (
+                  <strong>ID {canvasCourseId}</strong>
+                )}
+              </div>
+            </div>
+
+            <div className="text-sm text-muted-foreground">
+              <p>For each quiz in this course, the sync will:</p>
+              <ul className="list-disc pl-5 space-y-1 mt-1">
+                <li>Create a Canvas assignment (or reuse one from a previous sync)</li>
+                <li>Push each student&apos;s best score</li>
+                <li>Match students by email address</li>
+              </ul>
+            </div>
           </div>
 
           <DialogFooter>

--- a/src/lib/canvas/client.ts
+++ b/src/lib/canvas/client.ts
@@ -1,9 +1,13 @@
 /**
  * Canvas LMS REST API client for grade sync.
  *
- * Uses a personal access token stored in environment variables.
+ * Each faculty member stores their own encrypted Canvas API token.
  * All methods are server-side only (used in API routes).
  */
+
+import { prisma } from '@/lib/db';
+import { withDatabaseRetry } from '@/lib/retry';
+import { decrypt } from './encryption';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -14,11 +18,42 @@ export interface CanvasConfig {
   token: string;
 }
 
-export function getCanvasConfig(): CanvasConfig | null {
+/**
+ * Get Canvas config for a specific faculty member.
+ * Reads their encrypted token from the database and decrypts it.
+ * Returns null if CANVAS_BASE_URL is not set or the user has no token.
+ */
+export async function getCanvasConfigForUser(userId: string): Promise<CanvasConfig | null> {
   const baseUrl = process.env.CANVAS_BASE_URL;
-  const token = process.env.CANVAS_API_TOKEN;
-  if (!baseUrl || !token) return null;
+  if (!baseUrl) return null;
+
+  const user = await withDatabaseRetry(() =>
+    prisma.users.findUnique({
+      where: { id: userId },
+      select: { canvas_api_token_encrypted: true },
+    })
+  );
+
+  if (!user?.canvas_api_token_encrypted) return null;
+
+  const token = decrypt(user.canvas_api_token_encrypted);
+  if (!token) {
+    console.warn(`Failed to decrypt Canvas token for user ${userId} — token may need to be re-entered.`);
+    return null;
+  }
+
   return { baseUrl: baseUrl.replace(/\/+$/, ''), token };
+}
+
+/**
+ * Validate a Canvas API token by calling GET /api/v1/users/self.
+ * Used to verify a token before saving it.
+ */
+export async function validateCanvasToken(
+  config: CanvasConfig
+): Promise<CanvasResult<{ id: number; name: string }>> {
+  const res = await canvasFetch(config, '/api/v1/users/self');
+  return handleResponse<{ id: number; name: string }>(res);
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +145,18 @@ function getNextPageUrl(linkHeader: string | null): string | null {
 // ---------------------------------------------------------------------------
 // API methods
 // ---------------------------------------------------------------------------
+
+/**
+ * Fetch basic info about a Canvas course (name, code).
+ * Used to verify a Canvas Course ID before linking or syncing.
+ */
+export async function getCanvasCourse(
+  config: CanvasConfig,
+  canvasCourseId: string
+): Promise<CanvasResult<{ id: number; name: string; course_code: string }>> {
+  const res = await canvasFetch(config, `/api/v1/courses/${canvasCourseId}`);
+  return handleResponse<{ id: number; name: string; course_code: string }>(res);
+}
 
 /**
  * List all students enrolled in a Canvas course.

--- a/src/lib/canvas/encryption.ts
+++ b/src/lib/canvas/encryption.ts
@@ -1,0 +1,66 @@
+import crypto from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 12
+const AUTH_TAG_LENGTH = 16
+
+/**
+ * Read and validate the encryption key from environment.
+ * Must be exactly 32 bytes (64 hex characters).
+ */
+function getEncryptionKey(): Buffer {
+  const keyHex = process.env.CANVAS_TOKEN_ENCRYPTION_KEY
+  if (!keyHex) {
+    throw new Error(
+      'CANVAS_TOKEN_ENCRYPTION_KEY environment variable is required for Canvas token encryption. ' +
+      'Generate one with: openssl rand -hex 32'
+    )
+  }
+  if (!/^[0-9a-fA-F]{64}$/.test(keyHex)) {
+    throw new Error(
+      'CANVAS_TOKEN_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes).'
+    )
+  }
+  return Buffer.from(keyHex, 'hex')
+}
+
+/**
+ * Encrypt a plaintext Canvas API token.
+ * Returns a string in the format: iv_hex:authTag_hex:ciphertext_hex
+ */
+export function encrypt(plaintext: string): string {
+  const key = getEncryptionKey()
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH })
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`
+}
+
+/**
+ * Decrypt an encrypted Canvas API token.
+ * Expects the format: iv_hex:authTag_hex:ciphertext_hex
+ * Returns null if decryption fails (e.g. key rotation).
+ */
+export function decrypt(stored: string): string | null {
+  try {
+    const key = getEncryptionKey()
+    const parts = stored.split(':')
+    if (parts.length !== 3) return null
+
+    const iv = Buffer.from(parts[0], 'hex')
+    const authTag = Buffer.from(parts[1], 'hex')
+    const ciphertext = Buffer.from(parts[2], 'hex')
+
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH })
+    decipher.setAuthTag(authTag)
+
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    return decrypted.toString('utf8')
+  } catch {
+    // Decryption failed — likely key rotation or tampered data
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- Each faculty member now manages their own Canvas API token via **Profile > Edit > Canvas LMS Integration** (both faculty and admin profile pages)
- Tokens are encrypted at rest using AES-256-GCM (new `CANVAS_TOKEN_ENCRYPTION_KEY` env var)
- Canvas Course IDs must be **verified** (shows course name from Canvas) before saving on a group
- Sync confirmation dialog now shows the Canvas course name so faculty can double-check before pushing grades
- Removed `CANVAS_API_TOKEN` and `CANVAS_ALLOWED_COURSE_IDS` global env vars — no longer needed

## Changes by commit

### 1. Add per-faculty Canvas API tokens with encrypted storage
- Add `canvas_api_token_encrypted` and `canvas_token_updated_at` fields to users table (migration included)
- Add AES-256-GCM encryption utility (`src/lib/canvas/encryption.ts`)
- Add token management API routes: PUT (save), DELETE (remove), GET status (never returns the token)
- Add Canvas Course ID verification endpoint — fetches course name from Canvas for confirmation
- Add `CanvasTokenSettings` component to faculty profile edit page
- Update sync route to use per-faculty tokens via `getCanvasConfigForUser()`
- Require Canvas Course ID verification before group save (prevents typos pushing to wrong course)
- Enhance sync confirmation dialog to show Canvas course name
- Remove `CANVAS_API_TOKEN` and `CANVAS_ALLOWED_COURSE_IDS` from env examples and docs
- Add `CANVAS_TOKEN_ENCRYPTION_KEY` to env examples

### 2. Add Canvas token settings to admin profile edit page
- Admins have superset of faculty access — they now see the same Canvas LMS Integration section on `/admin/profile/edit`

### 3. Update docs with Canvas token setup instructions
- **Faculty Guide**: expand section 10 with step-by-step Canvas token setup, group verification, and grade sync instructions; update section 16 with profile fields list
- **Admin Guide**: note that admins have all faculty capabilities including Canvas integration
- **Dev/Prod Workflow**: add dedicated `CANVAS_TOKEN_ENCRYPTION_KEY` generation section with `openssl rand -hex 32` command and rotation warnings
- **Canvas Integration Guide**: fix stale allowlist references, add UIUC token request link for restricted accounts

## Env var changes (Vercel — both dev and prod)
- **Add**: `CANVAS_TOKEN_ENCRYPTION_KEY` — generate with `openssl rand -hex 32` (use different keys for dev/prod). Mark as Sensitive in Vercel.
- **Remove**: `CANVAS_API_TOKEN` (replaced by per-faculty tokens)
- **Remove**: `CANVAS_ALLOWED_COURSE_IDS` (replaced by Canvas API course verification)

## Files changed

| File | Change |
|------|--------|
| `prisma/schema.prisma` | Add `canvas_api_token_encrypted`, `canvas_token_updated_at` to users |
| `prisma/migrations/20260511170409_add_per_faculty_canvas_token/` | Migration |
| `src/lib/canvas/encryption.ts` | **New** — AES-256-GCM encrypt/decrypt |
| `src/lib/canvas/client.ts` | Add `getCanvasConfigForUser()`, `validateCanvasToken()`, `getCanvasCourse()` |
| `src/app/api/faculty/canvas-token/route.ts` | **New** — PUT/DELETE token |
| `src/app/api/faculty/canvas-token/status/route.ts` | **New** — GET token status |
| `src/app/api/faculty/canvas-course/validate/route.ts` | **New** — GET course verification |
| `src/app/api/faculty/courses/[id]/canvas-sync/route.ts` | Use per-user token, remove allowlist |
| `src/components/faculty/CanvasTokenSettings.tsx` | **New** — Token management UI |
| `src/components/faculty/CourseGroupsManager.tsx` | Add Canvas Course ID verification |
| `src/components/faculty/analytics/CanvasSyncButton.tsx` | Enhanced confirmation dialog |
| `src/app/faculty/profile/edit/page.tsx` | Add CanvasTokenSettings |
| `src/app/admin/profile/edit/page.tsx` | Add CanvasTokenSettings |
| `.env.development.example` | Update Canvas env vars |
| `.env.production.example` | Update Canvas env vars |
| `docs/FACULTY_GUIDE.md` | Canvas token setup instructions |
| `docs/ADMIN_GUIDE.md` | Note admin has faculty capabilities |
| `docs/DEV_PROD_WORKFLOW.md` | Encryption key generation steps |
| `docs/CANVAS_LMS_INTEGRATION_GUIDE.md` | Fix stale references, add UIUC link |
| `CLAUDE.md` | Update env vars section |

## Tested on dev (bcs-web2.vercel.app)
- [x] Invalid token rejected with proper error
- [x] Status API never leaks token value
- [x] Course validation blocked without token configured
- [x] Non-numeric course ID rejected
- [x] All endpoints return 401 for unauthenticated requests
- [x] Group form Verify shows error when no token configured
- [x] Group save blocked with unverified Canvas Course ID
- [x] Canvas token on admin profile edit page works
- [x] Token status shows "configured" with date after saving
- [x] Canvas Course ID verification returns real course name ("dev_jwillits_260152: DEVELOPMENT - BCOG Testing")
- [x] Sync confirmation dialog shows Canvas course name
- [x] End-to-end grade sync: 2 quizzes synced, 1 student synced, 1 skipped (test email)